### PR TITLE
[FEAT][#15] JWT 토큰 로컬 관리를 위한 DataStore 환경 설정

### DIFF
--- a/core/datastore/build.gradle.kts
+++ b/core/datastore/build.gradle.kts
@@ -14,5 +14,6 @@ dependencies {
     implementations(
         libs.androidx.core,
         libs.androidx.datastore.preferences,
+        libs.kotlinx.serialization.json,
     )
 }

--- a/core/datastore/src/main/kotlin/com/nexters/ilab/android/core/datastore/MyClass.kt
+++ b/core/datastore/src/main/kotlin/com/nexters/ilab/android/core/datastore/MyClass.kt
@@ -1,3 +1,0 @@
-package com.nexters.ilab.android.core.datastore
-
-class MyClass

--- a/core/datastore/src/main/kotlin/com/nexters/ilab/android/core/datastore/TokenDataStore.kt
+++ b/core/datastore/src/main/kotlin/com/nexters/ilab/android/core/datastore/TokenDataStore.kt
@@ -1,0 +1,13 @@
+package com.nexters.ilab.android.core.datastore
+
+interface TokenDataStore {
+    suspend fun setAccessToken(accessToken: String)
+
+    suspend fun setRefreshToken(refreshToken: String)
+
+    suspend fun getAccessToken(): String
+
+    suspend fun getRefreshToken(): String
+
+    suspend fun clear()
+}

--- a/core/datastore/src/main/kotlin/com/nexters/ilab/android/core/datastore/TokenDataStoreImpl.kt
+++ b/core/datastore/src/main/kotlin/com/nexters/ilab/android/core/datastore/TokenDataStoreImpl.kt
@@ -1,0 +1,44 @@
+package com.nexters.ilab.android.core.datastore
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.first
+import java.io.IOException
+import javax.inject.Inject
+
+class TokenDataStoreImpl @Inject constructor(
+    private val dataStore: DataStore<Preferences>,
+) : TokenDataStore {
+    private companion object {
+        private val KEY_ACCESS_TOKEN = stringPreferencesKey("access_token")
+        private val KEY_REFRESH_TOKEN = stringPreferencesKey("refresh_token")
+    }
+
+    override suspend fun setAccessToken(accessToken: String) {
+        dataStore.edit { preferences -> preferences[KEY_ACCESS_TOKEN] = accessToken }
+    }
+
+    override suspend fun setRefreshToken(refreshToken: String) {
+        dataStore.edit { preferences -> preferences[KEY_REFRESH_TOKEN] = refreshToken }
+    }
+
+    override suspend fun getAccessToken(): String = dataStore.data
+        .catch { exception ->
+            if (exception is IOException) emit(emptyPreferences())
+            else throw exception
+        }.first()[KEY_ACCESS_TOKEN] ?: ""
+
+    override suspend fun getRefreshToken(): String = dataStore.data
+        .catch { exception ->
+            if (exception is IOException) emit(emptyPreferences())
+            else throw exception
+        }.first()[KEY_REFRESH_TOKEN] ?: ""
+
+    override suspend fun clear() {
+        dataStore.edit { it.clear() }
+    }
+}

--- a/core/datastore/src/main/kotlin/com/nexters/ilab/android/core/datastore/di/DataStoreModule.kt
+++ b/core/datastore/src/main/kotlin/com/nexters/ilab/android/core/datastore/di/DataStoreModule.kt
@@ -1,0 +1,29 @@
+package com.nexters.ilab.android.core.datastore.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+import com.nexters.ilab.android.core.datastore.TokenDataStoreImpl
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+private const val TOKEN_DATASTORE = "token_datastore"
+private val Context.tokenDataStore: DataStore<Preferences> by preferencesDataStore(name = TOKEN_DATASTORE)
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal object DataStoreModule {
+
+    @Singleton
+    @Provides
+    internal fun providePreferencesDataStore(@ApplicationContext context: Context) = context.tokenDataStore
+
+    @Singleton
+    @Provides
+    internal fun provideTokenDataStore(dataStore: DataStore<Preferences>) = TokenDataStoreImpl(dataStore)
+}


### PR DESCRIPTION
- datastore 모듈 내에 JWT 토큰 로컬 관리를 위한 DataStore 환경 설정 완료
- 이후 network 모듈에서 datastore 를 사용할 예정(API 호출시 accessToken 을 헤더에 추가, 만료될 경우 refresh 토큰을 통한 새 토큰 발급 etc)