### PR TITLE
[FEAT] 앱에서 사용할 확장 함수 및 클래스 추가 

### DIFF
--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -2,6 +2,7 @@
 
 plugins {
     alias(libs.plugins.ilab.android.library)
+    alias(libs.plugins.ilab.android.library.compose)
 }
 
 android {

--- a/core/common/src/main/kotlin/com/nexters/ilab/android/core/common/MultipleEventsCutter.kt
+++ b/core/common/src/main/kotlin/com/nexters/ilab/android/core/common/MultipleEventsCutter.kt
@@ -1,0 +1,24 @@
+package com.nexters.ilab.android.core.common
+
+internal interface MultipleEventsCutter {
+    fun processEvent(event: () -> Unit)
+
+    companion object
+}
+
+internal fun MultipleEventsCutter.Companion.get(): MultipleEventsCutter =
+    MultipleEventsCutterImpl()
+
+private class MultipleEventsCutterImpl : MultipleEventsCutter {
+    private val now: Long
+        get() = System.currentTimeMillis()
+
+    private var lastEventTimeMs: Long = 0
+
+    override fun processEvent(event: () -> Unit) {
+        if (now - lastEventTimeMs >= 500L) {
+            event.invoke()
+        }
+        lastEventTimeMs = now
+    }
+}

--- a/core/common/src/main/kotlin/com/nexters/ilab/android/core/common/ObserveEvent.kt
+++ b/core/common/src/main/kotlin/com/nexters/ilab/android/core/common/ObserveEvent.kt
@@ -1,0 +1,23 @@
+package com.nexters.ilab.android.core.common
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.repeatOnLifecycle
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.withContext
+
+// https://www.youtube.com/watch?v=njchj9d_Lf8&t=1218s
+@Composable
+fun <T> ObserveAsEvents(flow: Flow<T>, onEvent: (T) -> Unit) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+    LaunchedEffect(flow, lifecycleOwner.lifecycle) {
+        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            withContext(Dispatchers.Main.immediate) {
+                flow.collect(onEvent)
+            }
+        }
+    }
+}

--- a/core/common/src/main/kotlin/com/nexters/ilab/android/core/common/UiText.kt
+++ b/core/common/src/main/kotlin/com/nexters/ilab/android/core/common/UiText.kt
@@ -1,0 +1,27 @@
+package com.nexters.ilab.android.core.common
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+
+// https://www.youtube.com/watch?v=mB1Lej0aDus
+sealed class UiText {
+    data class DirectString(val value: String) : UiText()
+
+    class StringResource(
+        @StringRes val resId: Int,
+        vararg val args: Any,
+    ) : UiText()
+
+    @Composable
+    fun asString() = when (this) {
+        is DirectString -> value
+        is StringResource -> stringResource(resId, *args)
+    }
+
+    fun asString(context: Context) = when (this) {
+        is DirectString -> value
+        is StringResource -> context.getString(resId, *args)
+    }
+}

--- a/core/common/src/main/kotlin/com/nexters/ilab/android/core/common/extension/Modifier.kt
+++ b/core/common/src/main/kotlin/com/nexters/ilab/android/core/common/extension/Modifier.kt
@@ -1,0 +1,86 @@
+@file:OptIn(ExperimentalLayoutApi::class)
+
+package com.nexters.ilab.android.core.common.extension
+
+import android.annotation.SuppressLint
+import androidx.compose.foundation.LocalIndication
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.isImeVisible
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.focus.onFocusEvent
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.debugInspectorInfo
+import androidx.compose.ui.semantics.Role
+import com.nexters.ilab.android.core.common.MultipleEventsCutter
+import com.nexters.ilab.android.core.common.get
+
+// https://stackoverflow.com/questions/66703448/how-to-disable-ripple-effect-when-clicking-in-jetpack-compose
+@SuppressLint("ModifierFactoryUnreferencedReceiver")
+inline fun Modifier.noRippleClickable(crossinline onClick: () -> Unit): Modifier = composed {
+    clickable(
+        indication = null,
+        interactionSource = remember { MutableInteractionSource() },
+    ) {
+        onClick()
+    }
+}
+
+// https://al-e-shevelev.medium.com/how-to-prevent-multiple-clicks-in-android-jetpack-compose-8e62224c9c5e
+fun Modifier.clickableSingle(
+    enabled: Boolean = true,
+    onClickLabel: String? = null,
+    role: Role? = null,
+    onClick: () -> Unit,
+) = composed(
+    inspectorInfo = debugInspectorInfo {
+        name = "clickable"
+        properties["enabled"] = enabled
+        properties["onClickLabel"] = onClickLabel
+        properties["role"] = role
+        properties["onClick"] = onClick
+    },
+) {
+    val multipleEventsCutter = remember { MultipleEventsCutter.get() }
+    Modifier.clickable(
+        enabled = enabled,
+        onClickLabel = onClickLabel,
+        onClick = { multipleEventsCutter.processEvent { onClick() } },
+        role = role,
+        indication = LocalIndication.current,
+        interactionSource = remember { MutableInteractionSource() },
+    )
+}
+
+// https://stackoverflow.com/questions/68389802/how-to-clear-textfield-focus-when-closing-the-keyboard-and-prevent-two-back-pres
+fun Modifier.clearFocusOnKeyboardDismiss(): Modifier = composed {
+    var isFocused by remember { mutableStateOf(false) }
+    var keyboardAppearedSinceLastFocused by remember { mutableStateOf(false) }
+    if (isFocused) {
+        val imeIsVisible = WindowInsets.isImeVisible
+        val focusManager = LocalFocusManager.current
+        LaunchedEffect(imeIsVisible) {
+            if (imeIsVisible) {
+                keyboardAppearedSinceLastFocused = true
+            } else if (keyboardAppearedSinceLastFocused) {
+                focusManager.clearFocus()
+            }
+        }
+    }
+    onFocusEvent {
+        if (isFocused != it.isFocused) {
+            isFocused = it.isFocused
+            if (isFocused) {
+                keyboardAppearedSinceLastFocused = false
+            }
+        }
+    }
+}

--- a/core/ui/src/main/kotlin/com/nexters/ilab/core/ui/ComponentPreview.kt
+++ b/core/ui/src/main/kotlin/com/nexters/ilab/core/ui/ComponentPreview.kt
@@ -1,0 +1,6 @@
+package com.nexters.ilab.core.ui
+
+import androidx.compose.ui.tooling.preview.Preview
+
+@Preview(showBackground = true)
+annotation class ComponentPreview

--- a/core/ui/src/main/kotlin/com/nexters/ilab/core/ui/DevicePreview.kt
+++ b/core/ui/src/main/kotlin/com/nexters/ilab/core/ui/DevicePreview.kt
@@ -1,0 +1,10 @@
+package com.nexters.ilab.core.ui
+
+import androidx.compose.ui.tooling.preview.Preview
+
+@Preview(
+    name = "Portrait",
+    showBackground = true,
+    device = "spec:width=360dp,height=800dp,dpi=411",
+)
+annotation class DevicePreview

--- a/core/ui/src/main/kotlin/com/nexters/ilab/core/ui/MyClass.kt
+++ b/core/ui/src/main/kotlin/com/nexters/ilab/core/ui/MyClass.kt
@@ -1,3 +1,0 @@
-package com.nexters.ilab.core.ui
-
-class MyClass


### PR DESCRIPTION
- 따로 이슈를 만들어서 진행 할만한 작업이 아니라 별도의 이슈 번호 기재 x
- Modifier 확장함수 추가(버튼 빠르게 두번 연속 클릭 방지, 버튼 클릭할때 ripple 효과 제거, keyboard 가 올라왔을 때 뒤로가기 버튼을 누를 경우 포커스는 빠지는데 키보드는 내려가지 않는 케이스 핸들링)
- Componet Preview 용, Screen Preview 용 annotation class 추가 
- 일회성 이벤트(Channel)가 Config Change 와 같은 상황에서 유실되는 것을 방지할 수 있는 함수 추가
- 뷰모델 내에서 String Resource 를 context 없이 우회하여 호출 할 수 있도록 하는 UiText sealed class 추가
- 각각의 함수 및 클래스에 대한 자세한 설명은 코드 상단에 적어둔 주석 참고 하면 좋을거 같아~