### PR TITLE
[FIX][#27] Setting 화면 클릭 영역 수정 및 DeleteAccount onclick 추가

### DIFF
--- a/feature/main/src/main/kotlin/com/nexters/ilab/android/feature/main/MainActivity.kt
+++ b/feature/main/src/main/kotlin/com/nexters/ilab/android/feature/main/MainActivity.kt
@@ -49,6 +49,12 @@ class MainActivity : ComponentActivity() {
                             withFinish = true,
                         )
                     },
+                    onDeleteAccountClick = {
+                        loginNavigator.navigateFrom(
+                            activity = this,
+                            withFinish = true,
+                        )
+                    },
                     navigator = navigator,
                 )
             }

--- a/feature/main/src/main/kotlin/com/nexters/ilab/android/feature/main/MainScreen.kt
+++ b/feature/main/src/main/kotlin/com/nexters/ilab/android/feature/main/MainScreen.kt
@@ -51,6 +51,7 @@ import java.net.UnknownHostException
 internal fun MainScreen(
     onChangeDarkTheme: (Boolean) -> Unit,
     onLogoutClick: () -> Unit,
+    onDeleteAccountClick: () -> Unit,
     navigator: MainNavController = rememberMainNavController(),
 ) {
     val snackBarHostState = remember { SnackbarHostState() }
@@ -99,6 +100,7 @@ internal fun MainScreen(
                         onBackClick = navigator::popBackStackIfNotHome,
                         onChangeDarkTheme = onChangeDarkTheme,
                         onLogoutClick = onLogoutClick,
+                        onDeleteAccountClick = onDeleteAccountClick,
                         onShowErrorSnackBar = onShowErrorSnackBar,
                     )
                 }

--- a/feature/setting/src/main/kotlin/com/nexters/ilab/android/feature/setting/SettingScreen.kt
+++ b/feature/setting/src/main/kotlin/com/nexters/ilab/android/feature/setting/SettingScreen.kt
@@ -2,7 +2,6 @@ package com.nexters.ilab.android.feature.setting
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import com.nexters.ilab.android.core.designsystem.R
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -20,10 +19,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.nexters.ilab.android.core.designsystem.R
 import com.nexters.ilab.android.core.designsystem.theme.Contents1
 import com.nexters.ilab.android.core.designsystem.theme.Gray100
 import com.nexters.ilab.android.core.designsystem.theme.Gray200
@@ -70,7 +70,10 @@ internal fun SettingScreen(
 }
 
 @Composable
-internal fun SettingContent(onLogoutClick: () -> Unit, onDeleteAccountClick: () -> Unit) {
+internal fun SettingContent(
+    onLogoutClick: () -> Unit,
+    onDeleteAccountClick: () -> Unit,
+) {
     SettingCellNavigation(R.string.setting_privacy)
     Spacer(
         modifier = Modifier
@@ -131,13 +134,16 @@ internal fun SettingCellText(stringId: Int, version: String) {
 }
 
 @Composable
-internal fun SettingCellNavigation(stringId: Int, onNavigationClick: () -> Unit = {}) {
+internal fun SettingCellNavigation(
+    stringId: Int,
+    onNavigationClick: () -> Unit = {},
+) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .height(64.dp)
-            .padding(start = 20.dp, end = 20.dp)
-            .clickable(onClick = onNavigationClick),
+            .clickable(onClick = onNavigationClick)
+            .padding(start = 20.dp, end = 20.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(

--- a/feature/setting/src/main/kotlin/com/nexters/ilab/android/feature/setting/SettingScreen.kt
+++ b/feature/setting/src/main/kotlin/com/nexters/ilab/android/feature/setting/SettingScreen.kt
@@ -12,10 +12,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -104,7 +102,7 @@ internal fun SettingContent(onLogoutClick: () -> Unit, onDeleteAccountClick: () 
             text = stringResource(id = R.string.setting_delete_account),
             style = Contents1,
             color = Color.Black,
-            modifier = Modifier.clickable(onClick = onDeleteAccountClick)
+            modifier = Modifier.clickable(onClick = onDeleteAccountClick),
         )
     }
 }

--- a/feature/setting/src/main/kotlin/com/nexters/ilab/android/feature/setting/SettingScreen.kt
+++ b/feature/setting/src/main/kotlin/com/nexters/ilab/android/feature/setting/SettingScreen.kt
@@ -1,6 +1,7 @@
 package com.nexters.ilab.android.feature.setting
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import com.nexters.ilab.android.core.designsystem.R
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -39,6 +40,7 @@ internal fun SettingRoute(
     onBackClick: () -> Unit,
     onChangeDarkTheme: (Boolean) -> Unit,
     onLogoutClick: () -> Unit,
+    onDeleteAccountClick: () -> Unit,
     onShowErrorSnackBar: (throwable: Throwable?) -> Unit,
     viewModel: SettingViewModel = hiltViewModel(),
 ) {
@@ -46,6 +48,7 @@ internal fun SettingRoute(
         onBackClick = onBackClick,
         onChangeDarkTheme = onChangeDarkTheme,
         onLogoutClick = onLogoutClick,
+        onDeleteAccountClick = onDeleteAccountClick,
     )
 }
 
@@ -55,6 +58,7 @@ internal fun SettingScreen(
     onBackClick: () -> Unit,
     onChangeDarkTheme: (Boolean) -> Unit,
     onLogoutClick: () -> Unit,
+    onDeleteAccountClick: () -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -63,12 +67,12 @@ internal fun SettingScreen(
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         SettingTopAppBar(onBackClick)
-        SettingContent(onLogoutClick)
+        SettingContent(onLogoutClick, onDeleteAccountClick)
     }
 }
 
 @Composable
-internal fun SettingContent(onLogoutClick: () -> Unit) {
+internal fun SettingContent(onLogoutClick: () -> Unit, onDeleteAccountClick: () -> Unit) {
     SettingCellNavigation(R.string.setting_privacy)
     Spacer(
         modifier = Modifier
@@ -100,6 +104,7 @@ internal fun SettingContent(onLogoutClick: () -> Unit) {
             text = stringResource(id = R.string.setting_delete_account),
             style = Contents1,
             color = Color.Black,
+            modifier = Modifier.clickable(onClick = onDeleteAccountClick)
         )
     }
 }
@@ -174,5 +179,5 @@ internal fun SettingTopAppBar(onBackClick: () -> Unit) {
 @DevicePreview
 @Composable
 fun UploadPhotoScreenPreview() {
-    SettingScreen({}, {}, {})
+    SettingScreen({}, {}, {}, {})
 }

--- a/feature/setting/src/main/kotlin/com/nexters/ilab/android/feature/setting/SettingScreen.kt
+++ b/feature/setting/src/main/kotlin/com/nexters/ilab/android/feature/setting/SettingScreen.kt
@@ -138,7 +138,8 @@ internal fun SettingCellNavigation(stringId: Int, onNavigationClick: () -> Unit 
         modifier = Modifier
             .fillMaxWidth()
             .height(64.dp)
-            .padding(start = 20.dp, end = 20.dp),
+            .padding(start = 20.dp, end = 20.dp)
+            .clickable(onClick = onNavigationClick),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
@@ -147,19 +148,10 @@ internal fun SettingCellNavigation(stringId: Int, onNavigationClick: () -> Unit 
             color = Color.Black,
         )
         Spacer(modifier = Modifier.weight(1f))
-        IconButton(
-            onClick = onNavigationClick,
-            modifier = Modifier
-                .size(48.dp),
-        ) {
-            Row {
-                Spacer(modifier = Modifier.weight(1f))
-                Icon(
-                    imageVector = ImageVector.vectorResource(id = R.drawable.ic_arrow_next),
-                    contentDescription = null,
-                )
-            }
-        }
+        Icon(
+            imageVector = ImageVector.vectorResource(id = R.drawable.ic_arrow_next),
+            contentDescription = null,
+        )
     }
 }
 

--- a/feature/setting/src/main/kotlin/com/nexters/ilab/android/feature/setting/navigation/SettingNavigation.kt
+++ b/feature/setting/src/main/kotlin/com/nexters/ilab/android/feature/setting/navigation/SettingNavigation.kt
@@ -17,6 +17,7 @@ fun NavGraphBuilder.settingNavGraph(
     onBackClick: () -> Unit,
     onChangeDarkTheme: (Boolean) -> Unit,
     onLogoutClick: () -> Unit,
+    onDeleteAccountClick: () -> Unit,
     onShowErrorSnackBar: (throwable: Throwable?) -> Unit,
 ) {
     composable(
@@ -38,6 +39,7 @@ fun NavGraphBuilder.settingNavGraph(
             onBackClick = onBackClick,
             onChangeDarkTheme = onChangeDarkTheme,
             onLogoutClick = onLogoutClick,
+            onDeleteAccountClick = onDeleteAccountClick,
             onShowErrorSnackBar = onShowErrorSnackBar,
         )
     }


### PR DESCRIPTION
- 계정 삭제 클릭시 이벤트를 연결했습니다~ 일단 구현된게 없어서 로그아웃과 똑같은 동작하도록 해놨으
- Setting 화면 클릭 영역을 IconButton -> Row 로 확장했습니다~
- 아래 사진에서 처럼 클릭하면 하나 Cell 전체에 반응하도록 연결해놨으

<img width="355" alt="스크린샷 2024-02-08 오전 12 37 12" src="https://github.com/Nexters/ilab-android/assets/63590121/52a7c006-d0dc-4649-9ada-ff8758883f22">
