### PR TITLE
[FEAT] [#9] 사진 가이드 화면 구현

### DIFF
--- a/core/data/src/main/kotlin/com/nexters/ilab/android/core/data/di/DataSourceModule.kt
+++ b/core/data/src/main/kotlin/com/nexters/ilab/android/core/data/di/DataSourceModule.kt
@@ -2,6 +2,10 @@ package com.nexters.ilab.android.core.data.di
 
 import com.nexters.ilab.android.core.data.datasource.FileDataSource
 import com.nexters.ilab.android.core.data.datasource.FileDataSourceImpl
+import com.nexters.ilab.android.core.datastore.PrivacyPolicyDataSource
+import com.nexters.ilab.android.core.datastore.PrivacyPolicyDataSourceImpl
+import com.nexters.ilab.android.core.datastore.TokenDataSource
+import com.nexters.ilab.android.core.datastore.TokenDataSourceImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -15,4 +19,12 @@ abstract class DataSourceModule {
     @Singleton
     @Binds
     abstract fun bindFileDataSource(fileDataSourceImpl: FileDataSourceImpl): FileDataSource
+
+    @Singleton
+    @Binds
+    abstract fun bindTokenDataSource(tokenDataSourceImpl: TokenDataSourceImpl): TokenDataSource
+
+    @Singleton
+    @Binds
+    abstract fun bindPrivacyPolicyDataSource(privacyPolicyDataSourceImpl: PrivacyPolicyDataSourceImpl): PrivacyPolicyDataSource
 }

--- a/core/data/src/main/kotlin/com/nexters/ilab/android/core/data/di/RepositoryModule.kt
+++ b/core/data/src/main/kotlin/com/nexters/ilab/android/core/data/di/RepositoryModule.kt
@@ -1,7 +1,9 @@
 package com.nexters.ilab.android.core.data.di
 
 import com.nexters.ilab.android.core.data.repository.FileRepositoryImpl
+import com.nexters.ilab.android.core.data.repository.PrivacyPolicyRepositoryImpl
 import com.nexters.ilab.android.core.domain.repository.FileRepository
+import com.nexters.ilab.android.core.domain.repository.PrivacyPolicyRepository
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -15,4 +17,8 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindFileRepository(fileRepositoryImpl: FileRepositoryImpl): FileRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindPrivacyPolicyRepository(privacyPolicyRepositoryImpl: PrivacyPolicyRepositoryImpl): PrivacyPolicyRepository
 }

--- a/core/data/src/main/kotlin/com/nexters/ilab/android/core/data/repository/PrivacyPolicyRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/nexters/ilab/android/core/data/repository/PrivacyPolicyRepositoryImpl.kt
@@ -1,0 +1,17 @@
+package com.nexters.ilab.android.core.data.repository
+
+import com.nexters.ilab.android.core.datastore.PrivacyPolicyDataSource
+import com.nexters.ilab.android.core.domain.repository.PrivacyPolicyRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class PrivacyPolicyRepositoryImpl @Inject constructor(
+    private val privacyPolicyDataSource: PrivacyPolicyDataSource,
+) : PrivacyPolicyRepository {
+    override fun getPrivacyPolicyAgreement(): Flow<Boolean> =
+        privacyPolicyDataSource.isPrivacyPolicyAgreed
+
+    override suspend fun setPrivacyPolicyAgreement(flag: Boolean) {
+        privacyPolicyDataSource.setPrivacyPolicyAgreement(flag)
+    }
+}

--- a/core/datastore/src/main/kotlin/com/nexters/ilab/android/core/datastore/PrivacyPolicyDataSource.kt
+++ b/core/datastore/src/main/kotlin/com/nexters/ilab/android/core/datastore/PrivacyPolicyDataSource.kt
@@ -1,0 +1,8 @@
+package com.nexters.ilab.android.core.datastore
+
+import kotlinx.coroutines.flow.Flow
+
+interface PrivacyPolicyDataSource {
+    val isPrivacyPolicyAgreed: Flow<Boolean>
+    suspend fun setPrivacyPolicyAgreement(flag: Boolean)
+}

--- a/core/datastore/src/main/kotlin/com/nexters/ilab/android/core/datastore/PrivacyPolicyDataSourceImpl.kt
+++ b/core/datastore/src/main/kotlin/com/nexters/ilab/android/core/datastore/PrivacyPolicyDataSourceImpl.kt
@@ -1,0 +1,25 @@
+package com.nexters.ilab.android.core.datastore
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import com.nexters.ilab.android.core.datastore.di.PrivacyPolicyDataStore
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class PrivacyPolicyDataSourceImpl @Inject constructor(
+    @PrivacyPolicyDataStore private val dataStore: DataStore<Preferences>,
+) : PrivacyPolicyDataSource {
+    private companion object {
+        private val KEY_PRIVACY_POLICY_AGREEMENT = booleanPreferencesKey("privacy_policy_agreement")
+    }
+
+    override val isPrivacyPolicyAgreed = dataStore.data.map { preferences ->
+        preferences[KEY_PRIVACY_POLICY_AGREEMENT] ?: false
+    }
+
+    override suspend fun setPrivacyPolicyAgreement(flag: Boolean) {
+        dataStore.edit { preferences -> preferences[KEY_PRIVACY_POLICY_AGREEMENT] = flag }
+    }
+}

--- a/core/datastore/src/main/kotlin/com/nexters/ilab/android/core/datastore/TokenDataSource.kt
+++ b/core/datastore/src/main/kotlin/com/nexters/ilab/android/core/datastore/TokenDataSource.kt
@@ -1,13 +1,9 @@
 package com.nexters.ilab.android.core.datastore
 
-interface TokenDataStore {
+interface TokenDataSource {
     suspend fun setAccessToken(accessToken: String)
-
     suspend fun setRefreshToken(refreshToken: String)
-
     suspend fun getAccessToken(): String
-
     suspend fun getRefreshToken(): String
-
     suspend fun clear()
 }

--- a/core/datastore/src/main/kotlin/com/nexters/ilab/android/core/datastore/TokenDataSourceImpl.kt
+++ b/core/datastore/src/main/kotlin/com/nexters/ilab/android/core/datastore/TokenDataSourceImpl.kt
@@ -5,14 +5,15 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.stringPreferencesKey
+import com.nexters.ilab.android.core.datastore.di.TokenDataStore
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.first
 import java.io.IOException
 import javax.inject.Inject
 
-class TokenDataStoreImpl @Inject constructor(
-    private val dataStore: DataStore<Preferences>,
-) : TokenDataStore {
+class TokenDataSourceImpl @Inject constructor(
+    @TokenDataStore val dataStore: DataStore<Preferences>,
+) : TokenDataSource {
     private companion object {
         private val KEY_ACCESS_TOKEN = stringPreferencesKey("access_token")
         private val KEY_REFRESH_TOKEN = stringPreferencesKey("refresh_token")

--- a/core/datastore/src/main/kotlin/com/nexters/ilab/android/core/datastore/di/DataStoreModule.kt
+++ b/core/datastore/src/main/kotlin/com/nexters/ilab/android/core/datastore/di/DataStoreModule.kt
@@ -4,7 +4,8 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStore
-import com.nexters.ilab.android.core.datastore.TokenDataStoreImpl
+import com.nexters.ilab.android.core.datastore.PrivacyPolicyDataSourceImpl
+import com.nexters.ilab.android.core.datastore.TokenDataSourceImpl
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -23,7 +24,13 @@ internal object DataStoreModule {
     @Provides
     internal fun providePreferencesDataStore(@ApplicationContext context: Context) = context.tokenDataStore
 
+    @TokenDataStore
     @Singleton
     @Provides
-    internal fun provideTokenDataStore(dataStore: DataStore<Preferences>) = TokenDataStoreImpl(dataStore)
+    internal fun provideTokenDataStore(dataStore: DataStore<Preferences>) = TokenDataSourceImpl(dataStore)
+
+    @PrivacyPolicyDataStore
+    @Singleton
+    @Provides
+    internal fun providePrivacyPolicyDataStore(dataStore: DataStore<Preferences>) = PrivacyPolicyDataSourceImpl(dataStore)
 }

--- a/core/datastore/src/main/kotlin/com/nexters/ilab/android/core/datastore/di/DataStoreModule.kt
+++ b/core/datastore/src/main/kotlin/com/nexters/ilab/android/core/datastore/di/DataStoreModule.kt
@@ -4,8 +4,6 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStore
-import com.nexters.ilab.android.core.datastore.PrivacyPolicyDataSourceImpl
-import com.nexters.ilab.android.core.datastore.TokenDataSourceImpl
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -16,21 +14,20 @@ import javax.inject.Singleton
 private const val TOKEN_DATASTORE = "token_datastore"
 private val Context.tokenDataStore: DataStore<Preferences> by preferencesDataStore(name = TOKEN_DATASTORE)
 
+private const val PRIVACY_POLICY_DATASTORE = "privacy_policy_datastore"
+private val Context.privacyPolicyDataStore: DataStore<Preferences> by preferencesDataStore(name = PRIVACY_POLICY_DATASTORE)
+
 @Module
 @InstallIn(SingletonComponent::class)
 internal object DataStoreModule {
 
-    @Singleton
-    @Provides
-    internal fun providePreferencesDataStore(@ApplicationContext context: Context) = context.tokenDataStore
-
     @TokenDataStore
     @Singleton
     @Provides
-    internal fun provideTokenDataStore(dataStore: DataStore<Preferences>) = TokenDataSourceImpl(dataStore)
+    internal fun provideTokenDataStore(@ApplicationContext context: Context) = context.tokenDataStore
 
     @PrivacyPolicyDataStore
     @Singleton
     @Provides
-    internal fun providePrivacyPolicyDataStore(dataStore: DataStore<Preferences>) = PrivacyPolicyDataSourceImpl(dataStore)
+    internal fun providePrivacyPolicyDataStore(@ApplicationContext context: Context) = context.privacyPolicyDataStore
 }

--- a/core/datastore/src/main/kotlin/com/nexters/ilab/android/core/datastore/di/DataStoreQualifier.kt
+++ b/core/datastore/src/main/kotlin/com/nexters/ilab/android/core/datastore/di/DataStoreQualifier.kt
@@ -1,0 +1,11 @@
+package com.nexters.ilab.android.core.datastore.di
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class TokenDataStore
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class PrivacyPolicyDataStore

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -7,5 +7,6 @@ plugins {
 dependencies {
     implementations(
         libs.javax.inject,
+        libs.kotlinx.coroutines.core,
     )
 }

--- a/core/domain/src/main/kotlin/com/nexters/ilab/android/core/domain/repository/PrivacyPolicyRepository.kt
+++ b/core/domain/src/main/kotlin/com/nexters/ilab/android/core/domain/repository/PrivacyPolicyRepository.kt
@@ -1,0 +1,8 @@
+package com.nexters.ilab.android.core.domain.repository
+
+import kotlinx.coroutines.flow.Flow
+
+interface PrivacyPolicyRepository {
+    fun getPrivacyPolicyAgreement(): Flow<Boolean>
+    suspend fun setPrivacyPolicyAgreement(flag: Boolean)
+}

--- a/feature/uploadphoto/src/main/kotlin/com/nexters/ilab/android/feature/uploadphoto/UploadPhotoScreen.kt
+++ b/feature/uploadphoto/src/main/kotlin/com/nexters/ilab/android/feature/uploadphoto/UploadPhotoScreen.kt
@@ -27,9 +27,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -128,6 +125,7 @@ internal fun UploadPhotoRoute(
     UploadPhotoScreen(
         uiState = uiState,
         onBackClick = onBackClick,
+        togglePrivacyPolicyAgreement = viewModel::togglePrivacyPolicyAgreement,
         openPhotoPicker = viewModel::openPhotoPicker,
         requestCameraPermission = viewModel::requestCameraPermission,
         dismissPermissionDialog = viewModel::dismissPermissionDialog,
@@ -138,6 +136,7 @@ internal fun UploadPhotoRoute(
 internal fun UploadPhotoScreen(
     uiState: UploadPhotoState,
     onBackClick: () -> Unit,
+    togglePrivacyPolicyAgreement: (Boolean) -> Unit,
     openPhotoPicker: () -> Unit,
     requestCameraPermission: () -> Unit,
     dismissPermissionDialog: () -> Unit,
@@ -165,6 +164,8 @@ internal fun UploadPhotoScreen(
 
         UploadPhotoTopAppBar(onBackClick = onBackClick)
         UploadPhotoContent(
+            isPrivacyPolicyAgreed = uiState.isPrivacyPolicyAgreed,
+            togglePrivacyPolicyAgreement = togglePrivacyPolicyAgreement,
             onPhotoPickerClick = openPhotoPicker,
             onCameraClick = requestCameraPermission,
         )
@@ -188,11 +189,11 @@ private fun UploadPhotoTopAppBar(
 
 @Composable
 private fun UploadPhotoContent(
+    isPrivacyPolicyAgreed: Boolean,
+    togglePrivacyPolicyAgreement: (Boolean) -> Unit,
     onPhotoPickerClick: () -> Unit,
     onCameraClick: () -> Unit,
 ) {
-    var checkedState by remember { mutableStateOf(false) }
-
     Box {
         Column(
             modifier = Modifier
@@ -262,11 +263,11 @@ private fun UploadPhotoContent(
             ) {
                 Row(
                     modifier = Modifier
-                        .clickable { checkedState = !checkedState }
+                        .clickable { togglePrivacyPolicyAgreement(!isPrivacyPolicyAgreed) }
                         .padding(4.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    PrivacyPolicyCheckBox(checked = checkedState)
+                    PrivacyPolicyCheckBox(checked = isPrivacyPolicyAgreed)
                     Spacer(modifier = Modifier.width(6.dp))
                     Text(
                         text = stringResource(id = R.string.personal_information_collection_and_usage_agreement),
@@ -300,6 +301,7 @@ private fun UploadPhotoContent(
                         .weight(1f)
                         .height(60.dp)
                         .padding(end = 4.dp),
+                    enabled = isPrivacyPolicyAgreed,
                     containerColor = PurpleBlue200,
                     contentColor = PurpleBlue900,
                     text = {
@@ -315,6 +317,7 @@ private fun UploadPhotoContent(
                         .weight(1f)
                         .height(60.dp)
                         .padding(start = 4.dp),
+                    enabled = isPrivacyPolicyAgreed,
                     text = {
                         Text(
                             text = stringResource(id = R.string.take_photo),
@@ -377,6 +380,7 @@ fun UploadPhotoScreenPreview() {
     UploadPhotoScreen(
         uiState = UploadPhotoState(),
         onBackClick = {},
+        togglePrivacyPolicyAgreement = { _ -> },
         openPhotoPicker = {},
         requestCameraPermission = {},
         dismissPermissionDialog = {},

--- a/feature/uploadphoto/src/main/kotlin/com/nexters/ilab/android/feature/uploadphoto/viewmodel/UploadPhotoState.kt
+++ b/feature/uploadphoto/src/main/kotlin/com/nexters/ilab/android/feature/uploadphoto/viewmodel/UploadPhotoState.kt
@@ -1,6 +1,7 @@
 package com.nexters.ilab.android.feature.uploadphoto.viewmodel
 
 data class UploadPhotoState(
+    val isPrivacyPolicyAgreed: Boolean = false,
     val selectedPhotoUri: String = "",
     val selectedStyle: String = "",
     val isPermissionDialogVisible: Boolean = false,

--- a/feature/uploadphoto/src/main/kotlin/com/nexters/ilab/android/feature/uploadphoto/viewmodel/UploadPhotoViewModel.kt
+++ b/feature/uploadphoto/src/main/kotlin/com/nexters/ilab/android/feature/uploadphoto/viewmodel/UploadPhotoViewModel.kt
@@ -1,7 +1,10 @@
 package com.nexters.ilab.android.feature.uploadphoto.viewmodel
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.nexters.ilab.android.core.domain.repository.PrivacyPolicyRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
@@ -10,9 +13,29 @@ import org.orbitmvi.orbit.viewmodel.container
 import javax.inject.Inject
 
 @HiltViewModel
-class UploadPhotoViewModel @Inject constructor() : ViewModel(), ContainerHost<UploadPhotoState, UploadPhotoSideEffect> {
+class UploadPhotoViewModel @Inject constructor(
+    private val privacyPolicyRepository: PrivacyPolicyRepository,
+) : ViewModel(), ContainerHost<UploadPhotoState, UploadPhotoSideEffect> {
 
     override val container = container<UploadPhotoState, UploadPhotoSideEffect>(UploadPhotoState())
+
+    init {
+        observePrivacyPolicyAgreement()
+    }
+
+    private fun observePrivacyPolicyAgreement() = intent {
+        viewModelScope.launch {
+            privacyPolicyRepository.getPrivacyPolicyAgreement().collect { isAgreed ->
+                reduce { state.copy(isPrivacyPolicyAgreed = isAgreed) }
+            }
+        }
+    }
+
+    fun togglePrivacyPolicyAgreement(flag: Boolean) {
+        viewModelScope.launch {
+            privacyPolicyRepository.setPrivacyPolicyAgreement(flag)
+        }
+    }
 
     fun openPhotoPicker() = intent {
         postSideEffect(UploadPhotoSideEffect.OpenPhotoPicker)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,6 +56,7 @@ gradle-android = { module = "com.android.tools.build:gradle", version.ref = "and
 gradle-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin-core" }
 
 kotlin-ktlint = { group = "com.pinterest", name = "ktlint", version.ref = "kotlin-ktlint-source" }
+kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "kotlinx-datetime" }
 kotlinx-collections-immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinx-collections-immutable" }


### PR DESCRIPTION
- 개인정보 수집 및 이용 동의 체크 여부를 DataStore 를 통해 로컬에 저장
- 체크 여부를 통해 사진 보관함, 사진 찍기 버튼 활성화 결정 
- **자세히** 를 누를 경우에 대한 웹뷰 정책이 정해지지 않아 이부분은 정해지면 따로 (설정 화면에서도 같은 로직 존재) 구현할 예정 