### PR TITLE
[FIX][#6] Home 화면 UI 수정

### DIFF
--- a/feature/home/src/main/kotlin/com/nexters/ilab/android/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/nexters/ilab/android/feature/home/HomeScreen.kt
@@ -126,14 +126,14 @@ internal fun HomeContent(
 
         itemsIndexed(profileImageList) { index, item ->
             val imageRatio = if (index % 6 == 1 || index % 6 == 3) imgSize.dp else (imgSize / 2 - 6).dp
-            val startDp =  if (index % 6 == 0 || index % 6 == 2 || index % 6 == 3)  20.dp else 0.dp
-            val endDp =  if (index % 6 == 0 || index % 6 == 2 || index % 6 == 3)  0.dp else 20.dp
+            val startDp = if (index % 6 == 0 || index % 6 == 2 || index % 6 == 3) 20.dp else 0.dp
+            val endDp = if (index % 6 == 0 || index % 6 == 2 || index % 6 == 3) 0.dp else 20.dp
 
             KeywordSampleImageItem(
                 profileImage = item,
                 imageRatio = imageRatio,
                 startDp = startDp,
-                endDp = endDp
+                endDp = endDp,
             )
         }
 
@@ -219,7 +219,7 @@ internal fun HomeKeywordView(
                 text = stringResource(id = R.string.home_profile),
                 style = Title2,
                 color = Color.Black,
-                modifier = Modifier.padding(start = 20.dp)
+                modifier = Modifier.padding(start = 20.dp),
             )
         }
     }
@@ -230,7 +230,7 @@ internal fun KeywordSampleImageItem(
     profileImage: ProfileImage,
     imageRatio: Dp,
     startDp: Dp,
-    endDp: Dp
+    endDp: Dp,
 ) {
     Box(
         modifier = Modifier

--- a/feature/home/src/main/kotlin/com/nexters/ilab/android/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/nexters/ilab/android/feature/home/HomeScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
@@ -28,9 +27,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -78,20 +79,11 @@ internal fun HomeScreen(
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         HomeTopAppBar(onSettingClick)
-        Box(modifier = Modifier.fillMaxSize()) {
-            BackgroundImage(
-                resId = R.drawable.bg_home_screen,
-                contentDescription = "Background Image for Home Screen",
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .wrapContentHeight(),
-            )
-            HomeContent(
-                styleImageList = uiState.styleImageList,
-                profileImageList = uiState.profileImageList,
-                onGenerateImgBtnClick = {},
-            )
-        }
+        HomeContent(
+            styleImageList = uiState.styleImageList,
+            profileImageList = uiState.profileImageList,
+            onGenerateImgBtnClick = {},
+        )
     }
 }
 
@@ -116,10 +108,12 @@ internal fun HomeContent(
     profileImageList: List<ProfileImage>,
     onGenerateImgBtnClick: () -> Unit,
 ) {
+    val configuration = LocalConfiguration.current
+    val imgSize = (configuration.screenWidthDp - 52)
+
     LazyVerticalStaggeredGrid(
         columns = StaggeredGridCells.Fixed(count = 2),
         modifier = Modifier.fillMaxSize(),
-        contentPadding = PaddingValues(start = 20.dp, end = 20.dp, bottom = 24.dp),
         horizontalArrangement = Arrangement.spacedBy(space = 12.dp),
         verticalItemSpacing = 12.dp,
     ) {
@@ -131,11 +125,20 @@ internal fun HomeContent(
         }
 
         itemsIndexed(profileImageList) { index, item ->
-            val imageHeight = if (index % 6 == 1 || index % 6 == 3) 336 else 162
+            val imageRatio = if (index % 6 == 1 || index % 6 == 3) imgSize.dp else (imgSize / 2 - 6).dp
+            val startDp =  if (index % 6 == 0 || index % 6 == 2 || index % 6 == 3)  20.dp else 0.dp
+            val endDp =  if (index % 6 == 0 || index % 6 == 2 || index % 6 == 3)  0.dp else 20.dp
+
             KeywordSampleImageItem(
                 profileImage = item,
-                imageHeight = imageHeight,
+                imageRatio = imageRatio,
+                startDp = startDp,
+                endDp = endDp
             )
+        }
+
+        item(span = StaggeredGridItemSpan.FullLine) {
+            Spacer(modifier = Modifier.height(24.dp))
         }
     }
 }
@@ -149,77 +152,92 @@ internal fun HomeKeywordView(
     val pageCount = styleImageList.size
     val pagerState = rememberPagerState(pageCount = { pageCount })
 
-    Column(modifier = Modifier.fillMaxSize()) {
-        Spacer(modifier = Modifier.height(32.dp))
-        Text(
-            text = stringResource(id = R.string.home_style),
-            color = Blue500,
-            style = Subtitle2,
-            modifier = Modifier.fillMaxWidth(),
-            textAlign = TextAlign.Center,
-        )
-        Spacer(modifier = Modifier.height(8.dp))
-        HorizontalPager(state = pagerState) { page ->
-            Column(
-                modifier = Modifier.fillMaxSize(),
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
-                Text(
-                    text = "#" + styleImageList[page].profileKeyword,
-                    textAlign = TextAlign.Center,
-                    style = Title1,
-                )
-                Spacer(modifier = Modifier.height(20.dp))
-                NetworkImage(
-                    imageUrl = styleImageList[page].profileImage,
-                    contentDescription = "Style Image Example ${page + 1}",
-                    modifier = Modifier
-                        .clip(RoundedCornerShape(topStart = 999.dp, topEnd = 999.dp))
-                        .size(width = 200.dp, height = 266.dp),
-                )
-            }
-        }
-        Spacer(modifier = Modifier.height(20.dp))
-        PagerIndicator(
-            pageCount = pagerState.pageCount,
-            currentPage = pagerState.currentPage,
-            targetPage = pagerState.currentPage,
-            currentPageOffsetFraction = pagerState.currentPageOffsetFraction,
-        )
-        Spacer(modifier = Modifier.height(32.dp))
-        ILabButton(
-            onClick = onGenerateImgBtnClick,
+    Box(modifier = Modifier.fillMaxSize()) {
+        BackgroundImage(
+            resId = R.drawable.bg_home_screen,
+            contentDescription = "Background Image for Home Screen",
             modifier = Modifier
                 .fillMaxWidth()
-                .height(48.dp),
-            containerColor = Blue600,
-            contentColor = Color.White,
-            text = {
-                Text(
-                    text = stringResource(id = R.string.home_generate_img_with_this_keyword),
-                    style = Subtitle1,
-                )
-            },
+                .wrapContentHeight(),
         )
-        Spacer(modifier = Modifier.height(40.dp))
-        Text(
-            text = stringResource(id = R.string.home_profile),
-            style = Title2,
-            color = Color.Black,
-        )
+
+        Column(modifier = Modifier.fillMaxSize()) {
+            Spacer(modifier = Modifier.height(32.dp))
+            Text(
+                text = stringResource(id = R.string.home_style),
+                color = Blue500,
+                style = Subtitle2,
+                modifier = Modifier.fillMaxWidth(),
+                textAlign = TextAlign.Center,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            HorizontalPager(state = pagerState) { page ->
+                Column(
+                    modifier = Modifier.fillMaxSize(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Text(
+                        text = "#" + styleImageList[page].profileKeyword,
+                        textAlign = TextAlign.Center,
+                        style = Title1,
+                    )
+                    Spacer(modifier = Modifier.height(20.dp))
+                    NetworkImage(
+                        imageUrl = styleImageList[page].profileImage,
+                        contentDescription = "Style Image Example ${page + 1}",
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(topStart = 999.dp, topEnd = 999.dp))
+                            .size(width = 200.dp, height = 266.dp),
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.height(20.dp))
+            PagerIndicator(
+                pageCount = pagerState.pageCount,
+                currentPage = pagerState.currentPage,
+                targetPage = pagerState.currentPage,
+                currentPageOffsetFraction = pagerState.currentPageOffsetFraction,
+            )
+            Spacer(modifier = Modifier.height(32.dp))
+            ILabButton(
+                onClick = onGenerateImgBtnClick,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 20.dp, end = 20.dp)
+                    .height(48.dp),
+                containerColor = Blue600,
+                contentColor = Color.White,
+                text = {
+                    Text(
+                        text = stringResource(id = R.string.home_generate_img_with_this_keyword),
+                        style = Subtitle1,
+                    )
+                },
+            )
+            Spacer(modifier = Modifier.height(40.dp))
+            Text(
+                text = stringResource(id = R.string.home_profile),
+                style = Title2,
+                color = Color.Black,
+                modifier = Modifier.padding(start = 20.dp)
+            )
+        }
     }
 }
 
 @Composable
 internal fun KeywordSampleImageItem(
     profileImage: ProfileImage,
-    imageHeight: Int,
+    imageRatio: Dp,
+    startDp: Dp,
+    endDp: Dp
 ) {
     Box(
         modifier = Modifier
-            .width(162.dp)
-            .height(height = imageHeight.dp)
+            .height(imageRatio)
+            .padding(start = startDp, end = endDp)
             .clip(RoundedCornerShape(12.dp)),
+
         contentAlignment = Alignment.Center,
     ) {
         NetworkImage(


### PR DESCRIPTION
- Home Bottom Navigation Bar padding 수정
- Grid Layout 값 화면 비율에 맞게 조정

1:2 비율 인덱스: screen width / 2 - 52(start, end padding + grid cell spacing) 
기본 인덱스: 위 값에 / 2 - 6 (grid cell spacing 2개에 적용되니까 그거 반)
맨 처음에는 고정값으로 ratio로 했는데 grid cell 사이의 padding 때문에 사이즈가 안맞아버리는 바람에 UI가 어긋나더라구
결국에 계산값 쓰기로 함

- Grid Layout 전체 padding 삭제 후 components 별로 padding 추가 (키워드 뷰 가로 스크롤 시 화면 padding에 잘리는 현상 삭제 위함)
- Home background Image scroll에 같이 포함되도록 수정
- ++ 나중에 screen width 와 같은 데이터는 viewModel로 빼둘 예정

----- 
<img width="354" alt="스크린샷 2024-02-23 오후 4 17 55" src="https://github.com/Nexters/ilab-android/assets/63590121/c9284195-8fa6-47db-b4de-d9ace9a71941">
<img width="354" alt="스크린샷 2024-02-23 오후 4 18 08" src="https://github.com/Nexters/ilab-android/assets/63590121/f329f0b8-ef79-4f37-bd1e-7cfad0a46f35">
