### PR TITLE
[FIX][#14] My Page 화면 bottom padding 수정

### DIFF
--- a/feature/mypage/src/main/kotlin/com/nexters/ilab/android/feature/mypage/MyPageScreen.kt
+++ b/feature/mypage/src/main/kotlin/com/nexters/ilab/android/feature/mypage/MyPageScreen.kt
@@ -126,7 +126,7 @@ internal fun MyPageContent(
         columns = GridCells.Adaptive(minSize = 162.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
         horizontalArrangement = Arrangement.spacedBy(12.dp),
-        modifier = Modifier.padding(top = 16.dp, start = 20.dp, end = 20.dp, bottom = 45.dp),
+        modifier = Modifier.padding(top = 16.dp, start = 20.dp, end = 20.dp),
     ) {
         item(span = span) {
             Column(
@@ -150,6 +150,9 @@ internal fun MyPageContent(
                     index = iter,
                 )
             }
+        }
+        item(span = span) {
+            Spacer(modifier = Modifier.height(24.dp))
         }
     }
 }


### PR DESCRIPTION
- my page 화면도 마찬가지로 bottom navigation에 잘리는 부분 삭제했습니다
- 스크롤 다 내리면 padding 보이도록 수정했습니다~
---
<img width="354" alt="스크린샷 2024-02-24 오후 8 07 47" src="https://github.com/Nexters/ilab-android/assets/63590121/01d9d44f-557b-4c00-a557-583fe0bb00a0">
<img width="354" alt="스크린샷 2024-02-24 오후 8 07 51" src="https://github.com/Nexters/ilab-android/assets/63590121/a80d02f9-0b98-4090-930d-8f34f89a9f61">
