### PR TITLE
[FEAT] 홈화면 내에 스타일로 프로필 생성하기 버튼을 통해, 스타일 입력화면내에 선택한 스타일이 체크되도록 구현 

### DIFF
--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.ilab.android.library)
     alias(libs.plugins.ilab.android.library.compose)
     alias(libs.plugins.ilab.android.hilt)
+    alias(libs.plugins.ilab.android.retrofit)
 }
 
 android {
@@ -16,7 +17,7 @@ dependencies {
         libs.androidx.core,
         libs.androidx.hilt.navigation.compose,
 
+        libs.timber,
         libs.bundles.androidx.lifecycle,
-
     )
 }

--- a/core/common/src/main/kotlin/com/nexters/ilab/android/core/common/HandleException.kt
+++ b/core/common/src/main/kotlin/com/nexters/ilab/android/core/common/HandleException.kt
@@ -1,0 +1,32 @@
+package com.nexters.ilab.android.core.common
+
+import retrofit2.HttpException
+import timber.log.Timber
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+
+interface ErrorHandlerActions {
+    fun openServerErrorDialog()
+    fun openNetworkErrorDialog()
+}
+
+fun handleException(exception: Throwable, actions: ErrorHandlerActions) {
+    when (exception) {
+        is HttpException -> {
+            if (exception.code() == 500) {
+                actions.openServerErrorDialog()
+            } else {
+                Timber.e(exception)
+            }
+        }
+        is UnknownHostException -> {
+            actions.openNetworkErrorDialog()
+        }
+        is SocketTimeoutException -> {
+            actions.openServerErrorDialog()
+        }
+        else -> {
+            Timber.e(exception)
+        }
+    }
+}

--- a/core/data/src/main/kotlin/com/nexters/ilab/android/core/data/datasource/AuthDataSource.kt
+++ b/core/data/src/main/kotlin/com/nexters/ilab/android/core/data/datasource/AuthDataSource.kt
@@ -5,6 +5,6 @@ import com.nexters.ilab.android.core.data.response.UserInfoResponse
 interface AuthDataSource {
     suspend fun signIn()
     suspend fun getUserInfo(uuid: Long): UserInfoResponse
-    suspend fun signOut()
-    suspend fun deleteAccount()
+    suspend fun signOut(uuid: Long)
+    suspend fun deleteAccount(uuid: Long)
 }

--- a/core/data/src/main/kotlin/com/nexters/ilab/android/core/data/datasource/AuthDataSourceImpl.kt
+++ b/core/data/src/main/kotlin/com/nexters/ilab/android/core/data/datasource/AuthDataSourceImpl.kt
@@ -16,11 +16,11 @@ class AuthDataSourceImpl @Inject constructor(
         return service.getUserInfo(uuid)
     }
 
-    override suspend fun signOut() {
-        service.signOut()
+    override suspend fun signOut(uuid: Long) {
+        service.signOut(uuid)
     }
 
-    override suspend fun deleteAccount() {
-        service.deleteAccount()
+    override suspend fun deleteAccount(uuid: Long) {
+        service.deleteAccount(uuid)
     }
 }

--- a/core/data/src/main/kotlin/com/nexters/ilab/android/core/data/repository/AuthRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/nexters/ilab/android/core/data/repository/AuthRepositoryImpl.kt
@@ -21,10 +21,12 @@ class AuthRepositoryImpl @Inject constructor(
     }
 
     override suspend fun signOut() = runSuspendCatching {
-        authDataSource.signOut()
+        val uuid = tokenDataSource.getUUID()
+        authDataSource.signOut(uuid)
     }
 
     override suspend fun deleteAccount() = runSuspendCatching {
-        authDataSource.deleteAccount()
+        val uuid = tokenDataSource.getUUID()
+        authDataSource.deleteAccount(uuid)
     }
 }

--- a/core/data/src/main/kotlin/com/nexters/ilab/android/core/data/service/AuthService.kt
+++ b/core/data/src/main/kotlin/com/nexters/ilab/android/core/data/service/AuthService.kt
@@ -15,9 +15,13 @@ interface AuthService {
         @Path("uuid") uuid: Long,
     ): UserInfoResponse
 
-    @POST("users/logout")
-    suspend fun signOut()
+    @POST("users/logout/{uuid}")
+    suspend fun signOut(
+        @Path("uuid") uuid: Long,
+    )
 
-    @POST("users/delete")
-    suspend fun deleteAccount()
+    @POST("users/delete/{uuid}")
+    suspend fun deleteAccount(
+        @Path("uuid") uuid: Long,
+    )
 }

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -2,7 +2,6 @@
 
 plugins {
     alias(libs.plugins.ilab.android.feature)
-    alias(libs.plugins.ilab.android.retrofit)
 }
 
 android {

--- a/feature/home/src/main/kotlin/com/nexters/ilab/android/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/nexters/ilab/android/feature/home/HomeScreen.kt
@@ -56,6 +56,7 @@ import com.nexters.ilab.android.core.designsystem.theme.Title1
 import com.nexters.ilab.android.core.designsystem.theme.Title2
 import com.nexters.ilab.android.core.domain.entity.ProfileEntity
 import com.nexters.ilab.android.core.domain.entity.StyleEntity
+import com.nexters.ilab.android.feature.home.viewmodel.HomeSideEffect
 import com.nexters.ilab.android.feature.home.viewmodel.HomeState
 import com.nexters.ilab.android.feature.home.viewmodel.HomeViewModel
 import com.nexters.ilab.core.ui.ComponentPreview
@@ -70,21 +71,30 @@ import com.nexters.ilab.core.ui.component.PagerIndicator
 import com.nexters.ilab.core.ui.component.ServerErrorDialog
 import com.nexters.ilab.core.ui.component.TopAppBarNavigationType
 
-@Suppress("unused")
 @Composable
 internal fun HomeRoute(
     padding: PaddingValues,
     onSettingClick: () -> Unit,
-    onGenerateImgBtnClick: () -> Unit,
+    onGenerateImgBtnClick: (String) -> Unit,
     viewModel: HomeViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.container.stateFlow.collectAsStateWithLifecycle()
+
+    LaunchedEffect(viewModel) {
+        viewModel.container.sideEffectFlow.collect { sideEffect ->
+            when (sideEffect) {
+                is HomeSideEffect.NavigateToUploadPhoto -> {
+                    onGenerateImgBtnClick(sideEffect.selectedStyle)
+                }
+            }
+        }
+    }
 
     HomeScreen(
         uiState = uiState,
         padding = padding,
         onSettingClick = onSettingClick,
-        onGenerateImgBtnClick = onGenerateImgBtnClick,
+        onGenerateImgBtnClick = viewModel::onGenerateImageClick,
         openProfileImageDialog = viewModel::openProfileImageDialog,
         dismissProfileImageDialog = viewModel::dismissProfileImageDialog,
         getStyleList = viewModel::getStyleList,
@@ -205,7 +215,10 @@ internal fun HomeContent(
                 imageRatio = imageRatio,
                 startDp = startDp,
                 endDp = endDp,
-                openProfileImageDialog = { openProfileImageDialog(index) },
+                openProfileImageDialog = {
+                    setSelectedStyleImage(index)
+                    openProfileImageDialog(index)
+                },
             )
         }
 

--- a/feature/home/src/main/kotlin/com/nexters/ilab/android/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/nexters/ilab/android/feature/home/HomeScreen.kt
@@ -94,7 +94,7 @@ internal fun HomeRoute(
         uiState = uiState,
         padding = padding,
         onSettingClick = onSettingClick,
-        onGenerateImgBtnClick = viewModel::onGenerateImageClick,
+        onGenerateImgBtnClick = viewModel::onGenerateImgBtnClick,
         openProfileImageDialog = viewModel::openProfileImageDialog,
         dismissProfileImageDialog = viewModel::dismissProfileImageDialog,
         getStyleList = viewModel::getStyleList,

--- a/feature/home/src/main/kotlin/com/nexters/ilab/android/feature/home/navigation/HomeNavigation.kt
+++ b/feature/home/src/main/kotlin/com/nexters/ilab/android/feature/home/navigation/HomeNavigation.kt
@@ -16,7 +16,7 @@ fun NavController.navigateToHome(navOptions: NavOptions) {
 fun NavGraphBuilder.homeNavGraph(
     padding: PaddingValues,
     onSettingClick: () -> Unit,
-    onGenerateImgBtnClick: () -> Unit,
+    onGenerateImgBtnClick: (String) -> Unit,
 ) {
     composable(route = HOME_ROUTE) {
         HomeRoute(

--- a/feature/home/src/main/kotlin/com/nexters/ilab/android/feature/home/viewmodel/HomeSideEffect.kt
+++ b/feature/home/src/main/kotlin/com/nexters/ilab/android/feature/home/viewmodel/HomeSideEffect.kt
@@ -1,6 +1,5 @@
 package com.nexters.ilab.android.feature.home.viewmodel
 
 sealed interface HomeSideEffect {
-    data class NavigateToUploadPhoto(val selectedStyle: String): HomeSideEffect
+    data class NavigateToUploadPhoto(val selectedStyle: String) : HomeSideEffect
 }
-

--- a/feature/home/src/main/kotlin/com/nexters/ilab/android/feature/home/viewmodel/HomeSideEffect.kt
+++ b/feature/home/src/main/kotlin/com/nexters/ilab/android/feature/home/viewmodel/HomeSideEffect.kt
@@ -1,3 +1,6 @@
 package com.nexters.ilab.android.feature.home.viewmodel
 
-interface HomeSideEffect
+sealed interface HomeSideEffect {
+    data class NavigateToUploadPhoto(val selectedStyle: String): HomeSideEffect
+}
+

--- a/feature/home/src/main/kotlin/com/nexters/ilab/android/feature/home/viewmodel/HomeState.kt
+++ b/feature/home/src/main/kotlin/com/nexters/ilab/android/feature/home/viewmodel/HomeState.kt
@@ -11,5 +11,5 @@ data class HomeState(
     val isServerErrorDialogVisible: Boolean = false,
     val isNetworkErrorDialogVisible: Boolean = false,
     val selectedProfileEntity: ProfileEntity = ProfileEntity("", "", ""),
-    val selectedStyleEntity: StyleEntity = StyleEntity(0, "", ""),
+    val selectedStyle: StyleEntity = StyleEntity(0, "", ""),
 )

--- a/feature/home/src/main/kotlin/com/nexters/ilab/android/feature/home/viewmodel/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/nexters/ilab/android/feature/home/viewmodel/HomeViewModel.kt
@@ -70,12 +70,15 @@ class HomeViewModel @Inject constructor(
                                 Timber.e(exception)
                             }
                         }
+
                         is UnknownHostException -> {
                             openNetworkErrorDialog()
                         }
+
                         is SocketTimeoutException -> {
                             openServerErrorDialog()
                         }
+
                         else -> {
                             Timber.e(exception)
                         }
@@ -96,7 +99,15 @@ class HomeViewModel @Inject constructor(
     }
 
     fun onGenerateImageClick() = intent {
-        postSideEffect(HomeSideEffect.NavigateToUploadPhoto(state.selectedStyle.name))
+        postSideEffect(
+            HomeSideEffect.NavigateToUploadPhoto(
+                if (state.selectedStyle.name.isEmpty()) {
+                    state.styleImageList[0].name
+                } else {
+                    state.selectedStyle.name
+                }
+            ),
+        )
     }
 
     fun openProfileImageDialog(index: Int) = intent {

--- a/feature/home/src/main/kotlin/com/nexters/ilab/android/feature/home/viewmodel/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/nexters/ilab/android/feature/home/viewmodel/HomeViewModel.kt
@@ -98,7 +98,7 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    fun onGenerateImageClick() = intent {
+    fun onGenerateImgBtnClick() = intent {
         postSideEffect(
             HomeSideEffect.NavigateToUploadPhoto(
                 if (state.selectedStyle.name.isEmpty()) {

--- a/feature/home/src/main/kotlin/com/nexters/ilab/android/feature/home/viewmodel/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/nexters/ilab/android/feature/home/viewmodel/HomeViewModel.kt
@@ -105,7 +105,7 @@ class HomeViewModel @Inject constructor(
                     state.styleImageList[0].name
                 } else {
                     state.selectedStyle.name
-                }
+                },
             ),
         )
     }

--- a/feature/login/src/main/kotlin/com/nexters/ilab/android/feature/login/LoginScreen.kt
+++ b/feature/login/src/main/kotlin/com/nexters/ilab/android/feature/login/LoginScreen.kt
@@ -49,6 +49,7 @@ import com.nexters.ilab.core.ui.component.LoadingIndicator
 import kotlinx.coroutines.launch
 import retrofit2.HttpException
 import timber.log.Timber
+import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 
 @Composable
@@ -73,7 +74,7 @@ internal fun LoginRoute(
                             resource.getString(R.string.unknown_error_message)
                         }
                     }
-
+                    is SocketTimeoutException -> resource.getString(R.string.server_error_message)
                     else -> resource.getString(R.string.unknown_error_message)
                 },
             )

--- a/feature/main/src/main/kotlin/com/nexters/ilab/android/feature/main/MainNavController.kt
+++ b/feature/main/src/main/kotlin/com/nexters/ilab/android/feature/main/MainNavController.kt
@@ -52,6 +52,10 @@ internal class MainNavController(
         }
     }
 
+    fun navigateToUploadPhoto(selectedStyle: String) {
+        navController.navigateToUploadPhoto(null, selectedStyle)
+    }
+
     fun navigateToUploadCheck() {
         navController.navigateToUploadCheck()
     }

--- a/feature/main/src/main/kotlin/com/nexters/ilab/android/feature/main/MainScreen.kt
+++ b/feature/main/src/main/kotlin/com/nexters/ilab/android/feature/main/MainScreen.kt
@@ -85,8 +85,8 @@ internal fun MainScreen(
                 homeNavGraph(
                     padding = padding,
                     onSettingClick = navigator::navigateToSetting,
-                    onGenerateImgBtnClick = {
-                        navigator.navigate(MainTab.UPLOAD_PHOTO)
+                    onGenerateImgBtnClick = { selectedStyle ->
+                        navigator.navigateToUploadPhoto(selectedStyle)
                     },
                 )
 

--- a/feature/mypage/build.gradle.kts
+++ b/feature/mypage/build.gradle.kts
@@ -2,7 +2,6 @@
 
 plugins {
     alias(libs.plugins.ilab.android.feature)
-    alias(libs.plugins.ilab.android.retrofit)
 }
 
 android {

--- a/feature/uploadphoto/build.gradle.kts
+++ b/feature/uploadphoto/build.gradle.kts
@@ -2,7 +2,6 @@
 
 plugins {
     alias(libs.plugins.ilab.android.feature)
-    alias(libs.plugins.ilab.android.retrofit)
 }
 
 android {

--- a/feature/uploadphoto/src/main/kotlin/com/nexters/ilab/android/feature/uploadphoto/InputStyleScreen.kt
+++ b/feature/uploadphoto/src/main/kotlin/com/nexters/ilab/android/feature/uploadphoto/InputStyleScreen.kt
@@ -103,6 +103,7 @@ internal fun InputStyleScreen(
         InputStyleTopAppBar(onBackClick = onBackClick)
         InputStyleContent(
             styleList = uiState.styleList.toImmutableList(),
+            selectedStyle = uiState.selectedStyle,
             isStyleSelected = uiState.selectedStyle.isNotEmpty(),
             onStyleSelect = onStyleSelect,
             createProfileImage = createProfileImage,
@@ -128,6 +129,7 @@ internal fun InputStyleTopAppBar(
 @Composable
 internal fun InputStyleContent(
     styleList: ImmutableList<StyleEntity>,
+    selectedStyle: String,
     isStyleSelected: Boolean,
     createProfileImage: () -> Unit,
     onStyleSelect: (String) -> Unit,
@@ -139,7 +141,8 @@ internal fun InputStyleContent(
                 .padding(horizontal = 20.dp),
         ) {
             CheckableStyleImageList(
-                images = styleList,
+                styleList = styleList,
+                selectedStyle = selectedStyle,
                 onStyleSelect = onStyleSelect,
                 modifier = Modifier
                     .fillMaxWidth()
@@ -169,11 +172,16 @@ internal fun InputStyleContent(
 
 @Composable
 fun CheckableStyleImageList(
-    images: ImmutableList<StyleEntity>,
+    styleList: ImmutableList<StyleEntity>,
+    selectedStyle: String,
     onStyleSelect: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var selectedItemIndex by remember { mutableStateOf<Int?>(null) }
+    var selectedItemIndex by remember {
+        mutableStateOf<Int?>(
+            styleList.indexOfFirst { it.name == selectedStyle },
+        )
+    }
 
     LazyVerticalGrid(
         columns = GridCells.Fixed(count = 3),
@@ -203,8 +211,8 @@ fun CheckableStyleImageList(
             }
         }
         items(
-            count = images.size,
-            key = { index -> images[index].id },
+            count = styleList.size,
+            key = { index -> styleList[index].id },
         ) { index ->
             val backgroundColor = if (selectedItemIndex == index) {
                 Blue600.copy(alpha = 0.6f)
@@ -212,8 +220,8 @@ fun CheckableStyleImageList(
                 Color.Transparent
             }
             StyleImage(
-                imageUrl = images[index].defaultImageUrl,
-                styleName = "#${images[index].name}",
+                imageUrl = styleList[index].defaultImageUrl,
+                styleName = "#${styleList[index].name}",
                 backgroundColor = backgroundColor,
                 contentDescription = "Style Image",
                 isSelectedIndex = selectedItemIndex == index,
@@ -223,7 +231,7 @@ fun CheckableStyleImageList(
                     .aspectRatio(1f)
                     .noRippleClickable {
                         selectedItemIndex = if (selectedItemIndex == index) null else index
-                        onStyleSelect(images[index].name)
+                        onStyleSelect(styleList[index].name)
                     },
             )
         }
@@ -248,13 +256,14 @@ fun InputStyleScreenPreview() {
 @Composable
 fun CheckableStyleImageListPreview() {
     CheckableStyleImageList(
-        images = persistentListOf(
+        styleList = persistentListOf(
             StyleEntity(
                 id = 0,
                 name = "ㅇㅇ",
                 defaultImageUrl = "",
             ),
         ),
+        selectedStyle = "",
         onStyleSelect = {},
     )
 }

--- a/feature/uploadphoto/src/main/kotlin/com/nexters/ilab/android/feature/uploadphoto/navigation/UploadPhotoNavigation.kt
+++ b/feature/uploadphoto/src/main/kotlin/com/nexters/ilab/android/feature/uploadphoto/navigation/UploadPhotoNavigation.kt
@@ -4,21 +4,31 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.NavOptions
+import androidx.navigation.NavType
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
+import androidx.navigation.navArgument
 import com.nexters.ilab.android.core.common.extension.sharedViewModel
 import com.nexters.ilab.android.feature.uploadphoto.InputStyleRoute
 import com.nexters.ilab.android.feature.uploadphoto.UploadCheckRoute
 import com.nexters.ilab.android.feature.uploadphoto.UploadPhotoRoute
 import com.nexters.ilab.android.feature.uploadphoto.viewmodel.UploadPhotoViewModel
 
-const val UPLOAD_PHOTO_ROUTE = "upload_photo_route"
+const val SELECTED_STYLE = "selected_style"
+const val UPLOAD_PHOTO_ROUTE = "upload_photo_route/{$SELECTED_STYLE}"
 const val UPLOAD_ROUTE = "upload_route"
 const val UPLOAD_CHECK_ROUTE = "upload_check_route"
 const val INPUT_STYLE_ROUTE = "input_style_route"
 
-fun NavController.navigateToUploadPhoto(navOptions: NavOptions) {
-    navigate(UPLOAD_PHOTO_ROUTE, navOptions)
+fun NavController.navigateToUploadPhoto(
+    navOptions: NavOptions?,
+    selectedStyle: String = "",
+) {
+    if (selectedStyle.isEmpty()) {
+        navigate(UPLOAD_PHOTO_ROUTE, navOptions)
+    } else {
+        navigate("upload_photo_route/$selectedStyle", navOptions)
+    }
 }
 
 fun NavController.navigateToUploadCheck() {
@@ -40,6 +50,11 @@ fun NavGraphBuilder.uploadPhotoNavGraph(
     navigation(
         startDestination = UPLOAD_ROUTE,
         route = UPLOAD_PHOTO_ROUTE,
+        arguments = listOf(
+            navArgument(SELECTED_STYLE) {
+                type = NavType.StringType
+            },
+        ),
     ) {
         composable(route = UPLOAD_ROUTE) { entry ->
             val viewModel = entry.sharedViewModel<UploadPhotoViewModel>(navController)

--- a/feature/uploadphoto/src/main/kotlin/com/nexters/ilab/android/feature/uploadphoto/viewmodel/UploadPhotoViewModel.kt
+++ b/feature/uploadphoto/src/main/kotlin/com/nexters/ilab/android/feature/uploadphoto/viewmodel/UploadPhotoViewModel.kt
@@ -29,7 +29,6 @@ class UploadPhotoViewModel @Inject constructor(
     private val selectedStyle = savedStateHandle[SELECTED_STYLE] ?: ""
 
     init {
-        Timber.d("selectedStyle: $selectedStyle")
         observePrivacyPolicyAgreement()
         getStyleList()
         setSelectedStyle(selectedStyle)
@@ -50,7 +49,6 @@ class UploadPhotoViewModel @Inject constructor(
             }
             styleRepository.getStyleList()
                 .onSuccess { styleList ->
-                    Timber.d("$styleList")
                     reduce {
                         state.copy(styleList = styleList)
                     }

--- a/feature/uploadphoto/src/main/kotlin/com/nexters/ilab/android/feature/uploadphoto/viewmodel/UploadPhotoViewModel.kt
+++ b/feature/uploadphoto/src/main/kotlin/com/nexters/ilab/android/feature/uploadphoto/viewmodel/UploadPhotoViewModel.kt
@@ -15,7 +15,6 @@ import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.viewmodel.container
-import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel


### PR DESCRIPTION
- 프로필 API 를 연동 후에도 정상적으로 작동하는지 테스트해봐야함(키워드를 클릭하였을 경우 출력되는 다이얼로그에도 해당 버튼이 포함되어있음)
- 스타일을 선택한 채로, 스타일 입력화면에 진입하는 것과, 선택하지 않은 채로(네비게이션 바 아이콘 클릭) 스타일 입력화면에 진입하는 것에 대한 분기 처리 추가
- 에러 핸들링 보일러 플레이트 코드 함수화 -> common 모듈로 이동(각 feature 모듈 내에 retrofit 의존성 제거)
- 엣지 케이스 예외 처리 
```kotlin
    LaunchedEffect(pagerState) {
        snapshotFlow { pagerState.currentPage }.collect { page ->
            setSelectedStyleImage(page)
        }
    }
```
현재 해당 코드를 통해 pager에 swipe 에 따른 currentPage 변화를 구독하는데, 초기 상황(홈화면 진입 후, 아직 한번도 swipe를 진행하지 않음)
에는 pagerState의 변화가 없으므로 style 이 선택되지 않음

따라서 우선, 
```kotlin
    fun onGenerateImgBtnClick() = intent {
        postSideEffect(
            HomeSideEffect.NavigateToUploadPhoto(
                if (state.selectedStyle.name.isEmpty()) {
                    state.styleImageList[0].name
                } else {
                    state.selectedStyle.name
                },
            ),
        )
    }
```
이런식으로 스타일로 프로필 생성하기 버튼을 눌렀는데, 선택된 스타일이 없다면 0번째 인덱스의 스타일이 선택되는 것으로 임시 처리
더 나은 해결방법이 없는지 고민 필요