### PR TITLE
[FEAT] [#88] 자동 로그인 구현 

### DIFF
--- a/feature/intro/src/main/kotlin/com/nexters/ilab/android/feature/intro/IntroActivity.kt
+++ b/feature/intro/src/main/kotlin/com/nexters/ilab/android/feature/intro/IntroActivity.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.activity.enableEdgeToEdge
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import com.nexters.ilab.android.core.designsystem.theme.ILabTheme
+import com.nexters.ilab.android.feature.intro.viewmodel.IntroViewModel
 import com.nexters.ilab.android.feature.navigator.LoginNavigator
 import com.nexters.ilab.android.feature.navigator.MainNavigator
 import dagger.hilt.android.AndroidEntryPoint

--- a/feature/intro/src/main/kotlin/com/nexters/ilab/android/feature/intro/IntroScreen.kt
+++ b/feature/intro/src/main/kotlin/com/nexters/ilab/android/feature/intro/IntroScreen.kt
@@ -17,20 +17,24 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.vectorResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.nexters.ilab.android.core.designsystem.R
+import com.nexters.ilab.android.feature.intro.viewmodel.IntroSideEffect
+import com.nexters.ilab.android.feature.intro.viewmodel.IntroViewModel
 import com.nexters.ilab.core.ui.DevicePreview
 import com.nexters.ilab.core.ui.component.BackgroundImage
-import kotlinx.coroutines.delay
 
-@Suppress("unused")
 @Composable
 internal fun IntroRoute(
     navigateToLogin: () -> Unit,
     navigateToMain: () -> Unit,
     viewModel: IntroViewModel = hiltViewModel(),
 ) {
-    LaunchedEffect(key1 = Unit) {
-        delay(1000)
-        navigateToLogin()
+    LaunchedEffect(viewModel) {
+        viewModel.container.sideEffectFlow.collect { sideEffect ->
+            when (sideEffect) {
+                is IntroSideEffect.AutoLoginSuccess -> navigateToMain()
+                is IntroSideEffect.AutoLoginFail -> navigateToLogin()
+            }
+        }
     }
 
     IntroScreen()

--- a/feature/intro/src/main/kotlin/com/nexters/ilab/android/feature/intro/IntroViewModel.kt
+++ b/feature/intro/src/main/kotlin/com/nexters/ilab/android/feature/intro/IntroViewModel.kt
@@ -1,8 +1,0 @@
-package com.nexters.ilab.android.feature.intro
-
-import androidx.lifecycle.ViewModel
-import dagger.hilt.android.lifecycle.HiltViewModel
-import javax.inject.Inject
-
-@HiltViewModel
-class IntroViewModel @Inject constructor() : ViewModel()

--- a/feature/intro/src/main/kotlin/com/nexters/ilab/android/feature/intro/viewmodel/IntroSideEffect.kt
+++ b/feature/intro/src/main/kotlin/com/nexters/ilab/android/feature/intro/viewmodel/IntroSideEffect.kt
@@ -1,0 +1,7 @@
+package com.nexters.ilab.android.feature.intro.viewmodel
+
+sealed interface IntroSideEffect {
+    data object AutoLoginSuccess : IntroSideEffect
+    data object AutoLoginFail : IntroSideEffect
+
+}

--- a/feature/intro/src/main/kotlin/com/nexters/ilab/android/feature/intro/viewmodel/IntroSideEffect.kt
+++ b/feature/intro/src/main/kotlin/com/nexters/ilab/android/feature/intro/viewmodel/IntroSideEffect.kt
@@ -3,5 +3,4 @@ package com.nexters.ilab.android.feature.intro.viewmodel
 sealed interface IntroSideEffect {
     data object AutoLoginSuccess : IntroSideEffect
     data object AutoLoginFail : IntroSideEffect
-
 }

--- a/feature/intro/src/main/kotlin/com/nexters/ilab/android/feature/intro/viewmodel/IntroState.kt
+++ b/feature/intro/src/main/kotlin/com/nexters/ilab/android/feature/intro/viewmodel/IntroState.kt
@@ -1,0 +1,5 @@
+package com.nexters.ilab.android.feature.intro.viewmodel
+
+data class IntroState(
+    val isLoading: Boolean = false,
+)

--- a/feature/intro/src/main/kotlin/com/nexters/ilab/android/feature/intro/viewmodel/IntroViewModel.kt
+++ b/feature/intro/src/main/kotlin/com/nexters/ilab/android/feature/intro/viewmodel/IntroViewModel.kt
@@ -1,0 +1,37 @@
+package com.nexters.ilab.android.feature.intro.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.nexters.ilab.android.core.domain.repository.TokenRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.syntax.simple.intent
+import org.orbitmvi.orbit.syntax.simple.postSideEffect
+import org.orbitmvi.orbit.viewmodel.container
+import javax.inject.Inject
+
+@HiltViewModel
+class IntroViewModel @Inject constructor(
+    private val repository: TokenRepository,
+) : ViewModel(), ContainerHost<IntroState, IntroSideEffect> {
+
+    override val container = container<IntroState, IntroSideEffect>(IntroState())
+
+    init {
+        getAccessToken()
+    }
+
+    private fun getAccessToken() = intent {
+        viewModelScope.launch {
+            delay(1000)
+            val accessToken = repository.getAccessToken()
+            if (accessToken.isNotEmpty()) {
+                postSideEffect(IntroSideEffect.AutoLoginSuccess)
+            } else {
+                postSideEffect(IntroSideEffect.AutoLoginFail)
+            }
+        }
+    }
+}

--- a/feature/login/src/main/kotlin/com/nexters/ilab/android/feature/login/viewmodel/LoginViewModel.kt
+++ b/feature/login/src/main/kotlin/com/nexters/ilab/android/feature/login/viewmodel/LoginViewModel.kt
@@ -33,13 +33,14 @@ class LoginViewModel @Inject constructor(
                 state.copy(isLoading = true)
             }
             tokenRepository.setAccessToken(accessToken)
-            tokenRepository.setUUID(uuid)
             loginRepository.signIn()
                 .onSuccess {
+                    tokenRepository.setUUID(uuid)
                     postSideEffect(LoginSideEffect.LoginSuccess)
                 }
                 .onFailure { exception ->
                     Timber.e(exception)
+                    tokenRepository.clear()
                     postSideEffect(LoginSideEffect.LoginFail(exception))
                 }
             reduce {


### PR DESCRIPTION
- State를 사용하진 않으나, IntroState 클래스가 없으면 orbit 과 관련된 함수들을 사용할 수 없어서 생성해둠(orbit의 단점 중 하나인듯)
- 로그인 로직 수정
  - 현재 자동 로그인 로직이 앱내에 저장된 accessToken이 있는지 여부로 판단
  - 기존의 로그인의 로직은 카카오 로그인이 성공할 경우, 헤더에 토큰을 담아, 서버 로그인을 진행하기 위해 우선 token을 저장하는 구조 였음
  - 따라서 서버 로그인이 실패하더라도 해당 토큰이 앱 내에 저장되어 있게 되어, 다음번 로그인시 자동 로그인이 성공하게 됨
  - 서버 로그인이 실패할 경우, 앱 내에 저장되어있는 토큰을 모두 지우는 로직 추가  