### PR TITLE
[FEAT] TokenInterceptor 가 포함된 OkHttpClient 와 포함되지 않은 OkHttpClient 를 분리 

### DIFF
--- a/core/data/src/main/kotlin/com/nexters/ilab/android/core/data/di/ApiModule.kt
+++ b/core/data/src/main/kotlin/com/nexters/ilab/android/core/data/di/ApiModule.kt
@@ -25,7 +25,7 @@ internal object ApiModule {
 
     @Singleton
     @Provides
-    internal fun provideLoginService(
+    internal fun provideAuthService(
         @LoginApi retrofit: Retrofit,
     ): AuthService {
         return retrofit.create(AuthService::class.java)

--- a/core/network/src/main/kotlin/com/nexters/ilab/android/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/kotlin/com/nexters/ilab/android/core/network/di/NetworkModule.kt
@@ -54,9 +54,24 @@ internal object NetworkModule {
         return TokenInterceptor(dataStore)
     }
 
+    @ILabClient
     @Singleton
     @Provides
-    internal fun provideOkHttpClient(
+    internal fun provideILabOkHttpClient(
+        httpLoggingInterceptor: HttpLoggingInterceptor,
+    ): OkHttpClient {
+        return OkHttpClient.Builder()
+            .connectTimeout(MaxTimeoutMillis, TimeUnit.MILLISECONDS)
+            .readTimeout(MaxTimeoutMillis, TimeUnit.MILLISECONDS)
+            .writeTimeout(MaxTimeoutMillis, TimeUnit.MILLISECONDS)
+            .addInterceptor(httpLoggingInterceptor)
+            .build()
+    }
+
+    @TokenClient
+    @Singleton
+    @Provides
+    internal fun provideTokenOkHttpClient(
         httpLoggingInterceptor: HttpLoggingInterceptor,
         tokenInterceptor: TokenInterceptor,
     ): OkHttpClient {
@@ -73,7 +88,7 @@ internal object NetworkModule {
     @Singleton
     @Provides
     internal fun provideILabApiRetrofit(
-        okHttpClient: OkHttpClient,
+        @ILabClient okHttpClient: OkHttpClient,
     ): Retrofit {
         return Retrofit.Builder()
             .baseUrl(BuildConfig.SERVER_BASE_URL)
@@ -85,8 +100,8 @@ internal object NetworkModule {
     @LoginApi
     @Singleton
     @Provides
-    internal fun provideLoginApiRetrofit(
-        okHttpClient: OkHttpClient,
+    internal fun provideAuthApiRetrofit(
+        @TokenClient okHttpClient: OkHttpClient,
     ): Retrofit {
         return Retrofit.Builder()
             .baseUrl(BuildConfig.SERVER_BASE_URL)
@@ -99,7 +114,7 @@ internal object NetworkModule {
     @Singleton
     @Provides
     internal fun provideFileApiRetrofit(
-        okHttpClient: OkHttpClient,
+        @ILabClient okHttpClient: OkHttpClient,
     ): Retrofit {
         return Retrofit.Builder()
             .baseUrl(BuildConfig.SERVER_BASE_URL)

--- a/core/network/src/main/kotlin/com/nexters/ilab/android/core/network/di/RetrofitQualifier.kt
+++ b/core/network/src/main/kotlin/com/nexters/ilab/android/core/network/di/RetrofitQualifier.kt
@@ -13,3 +13,12 @@ annotation class LoginApi
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class FileApi
+
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class TokenClient
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class ILabClient

--- a/core/network/src/main/kotlin/com/nexters/ilab/android/core/network/di/RetrofitQualifier.kt
+++ b/core/network/src/main/kotlin/com/nexters/ilab/android/core/network/di/RetrofitQualifier.kt
@@ -14,7 +14,6 @@ annotation class LoginApi
 @Retention(AnnotationRetention.BINARY)
 annotation class FileApi
 
-
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class TokenClient

--- a/core/ui/src/main/kotlin/com/nexters/ilab/core/ui/component/LoadingIndicator.kt
+++ b/core/ui/src/main/kotlin/com/nexters/ilab/core/ui/component/LoadingIndicator.kt
@@ -17,16 +17,11 @@ fun LoadingIndicator(modifier: Modifier = Modifier) {
         modifier = modifier.noRippleClickable {},
         contentAlignment = Alignment.Center,
     ) {
-        Box(
-            modifier = Modifier.fillMaxSize(),
-            contentAlignment = Alignment.Center,
-        ) {
-            LoadingImage(
-                resId = R.drawable.anim_loading,
-                contentDescription = "Loading image",
-                modifier = Modifier.size(70.dp),
-            )
-        }
+        LoadingImage(
+            resId = R.drawable.anim_loading,
+            contentDescription = "Loading image",
+            modifier = Modifier.size(70.dp),
+        )
     }
 }
 

--- a/feature/login/src/main/kotlin/com/nexters/ilab/android/feature/login/LoginScreen.kt
+++ b/feature/login/src/main/kotlin/com/nexters/ilab/android/feature/login/LoginScreen.kt
@@ -138,11 +138,11 @@ internal fun LoginScreen(
     uiState: LoginState,
     onLoginClick: () -> Unit,
 ) {
-    if (uiState.isLoading) {
-        LoadingIndicator(modifier = Modifier.fillMaxSize())
-    }
-
     Box(modifier = Modifier.fillMaxSize()) {
+        if (uiState.isLoading) {
+            LoadingIndicator(modifier = Modifier.fillMaxSize())
+        }
+
         BackgroundImage(
             resId = R.drawable.bg_login_screen,
             contentDescription = "Background Image for Login Screen",


### PR DESCRIPTION
- 헤더에 AccessToken 이 필요하지 않은 API 에는 헤더에 AccessToken 이 들어가지 않도록 수정
- 로딩 인디케이터 중첩 박스 단일 박스로 수정
- 로그인 화면내에 로딩 인디케이터가 보이지 않는 문제 수정(확인해보려고 했으나, 느렸던 로그인 API가 갑자기 빨라져서 로딩 인디케이터를 볼 수 없었음)