### PR TITLE
[FIX] 로그인 관련 예외 처리 추가

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -27,3 +27,12 @@
 # R8 full mode strips generic signatures from return types if not kept.
 -if interface * { @retrofit2.http.* public *** *(...); }
 -keep,allowoptimization,allowshrinking,allowobfuscation class <3>
+
+ # Keep generic signature of Call, Response (R8 full mode strips signatures from non-kept items).
+ -keep,allowobfuscation,allowshrinking interface retrofit2.Call
+ -keep,allowobfuscation,allowshrinking class retrofit2.Response
+
+ # With R8 full mode generic signatures are stripped for classes that are not
+ # kept. Suspend functions are wrapped in continuations where the type argument
+ # is used.
+ -keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation

--- a/build-logic/src/main/kotlin/com/nexters/ilab/android/Config.kt
+++ b/build-logic/src/main/kotlin/com/nexters/ilab/android/Config.kt
@@ -4,8 +4,8 @@ internal object ApplicationConfig {
     const val MinSdk = 26
     const val TargetSdk = 34
     const val CompileSdk = 34
-    const val VersionCode = 1
-    const val VersionName = "1.0.0"
+    const val VersionCode = 3
+    const val VersionName = "1.0.2"
     val JavaVersion = org.gradle.api.JavaVersion.VERSION_17
     const val JavaVersionAsInt = 17
 }

--- a/feature/intro/proguard-rules.pro
+++ b/feature/intro/proguard-rules.pro
@@ -1,0 +1,25 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile
+
+# https://stackoverflow.com/questions/70037537/proguard-missing-classes-detected-while-running-r8-after-adding-package-names-in
+-dontwarn java.lang.invoke.StringConcatFactory
+

--- a/feature/intro/src/main/kotlin/com/nexters/ilab/android/feature/intro/IntroScreen.kt
+++ b/feature/intro/src/main/kotlin/com/nexters/ilab/android/feature/intro/IntroScreen.kt
@@ -50,6 +50,7 @@ internal fun IntroRoute(
                                 }
                             } else {
                                 Timber.d("accessToken 이 유효함")
+                                Timber.d("id: ${tokeninfo?.id}, expiresIn: ${tokeninfo?.expiresIn}, appId: ${tokeninfo?.appId}")
                                 viewModel.autoLoginSuccess()
                             }
                         }

--- a/feature/intro/src/main/kotlin/com/nexters/ilab/android/feature/intro/viewmodel/IntroViewModel.kt
+++ b/feature/intro/src/main/kotlin/com/nexters/ilab/android/feature/intro/viewmodel/IntroViewModel.kt
@@ -10,6 +10,7 @@ import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.viewmodel.container
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -24,7 +25,16 @@ class IntroViewModel @Inject constructor(
     }
 
     private fun validateToken() = intent {
-        postSideEffect(IntroSideEffect.ValidateToken)
+        delay(1000)
+        viewModelScope.launch {
+            val accessToken = repository.getAccessToken()
+            if (accessToken.isNotEmpty()) {
+                Timber.d("accessToken: $accessToken")
+                postSideEffect(IntroSideEffect.ValidateToken)
+            } else {
+                postSideEffect(IntroSideEffect.AutoLoginFail)
+            }
+        }
     }
 
     fun autoLoginFail() = intent {
@@ -36,17 +46,5 @@ class IntroViewModel @Inject constructor(
 
     fun autoLoginSuccess() = intent {
         postSideEffect(IntroSideEffect.AutoLoginSuccess)
-    }
-
-    private fun getAccessToken() = intent {
-        viewModelScope.launch {
-            delay(1000)
-            val accessToken = repository.getAccessToken()
-            if (accessToken.isNotEmpty()) {
-                postSideEffect(IntroSideEffect.AutoLoginSuccess)
-            } else {
-                postSideEffect(IntroSideEffect.AutoLoginFail)
-            }
-        }
     }
 }

--- a/feature/mypage/src/main/kotlin/com/nexters/ilab/android/feature/mypage/viewmodel/MyPageViewModel.kt
+++ b/feature/mypage/src/main/kotlin/com/nexters/ilab/android/feature/mypage/viewmodel/MyPageViewModel.kt
@@ -15,7 +15,6 @@ import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.viewmodel.container
-import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -77,12 +76,6 @@ class MyPageViewModel @Inject constructor(
         }
     }
 
-    private fun setSelectedMyAlbum(index: Int) = intent {
-        reduce {
-            state.copy(selectedMyAlbum = index)
-        }
-    }
-
     fun shareMyAlbum() = intent {
         viewModelScope.launch {
             reduce {
@@ -105,16 +98,13 @@ class MyPageViewModel @Inject constructor(
     }
 
     fun onAlbumClick(index: Int) = intent {
-        Timber.d("before: state.selectedMyAlbum: ${state.selectedMyAlbum}")
-        setSelectedMyAlbum(index)
-        Timber.d("selectedIndex: $index")
-        Timber.d("state.selectedMyAlbum: ${state.selectedMyAlbum}")
-        Timber.d("MyAlbumImageUrlList: ${state.myAlbumFullImageList[state.selectedMyAlbum].images.map { it.imageUrl }}")
-        Timber.d("StyleName: ${state.myAlbumFullImageList[state.selectedMyAlbum].images.map { it.imageStyle.name }.first()}")
+        reduce {
+            state.copy(selectedMyAlbum = index)
+        }
         postSideEffect(
             MyPageSideEffect.NavigateToMyAlbum(
-                state.myAlbumFullImageList[index].images.map { it.imageUrl },
-                state.myAlbumFullImageList[index].images.map { it.imageStyle.name }.first(),
+                state.myAlbumFullImageList[state.selectedMyAlbum].images.map { it.imageUrl },
+                state.myAlbumFullImageList[state.selectedMyAlbum].images.map { it.imageStyle.name }.first(),
             ),
         )
     }


### PR DESCRIPTION
- intro 화면에서 카카오 측에서 accessToken의 유효성을 검사하기 이전에 accessToken을 앱에서 저장하고 있는지 검사하는 로직 추가

- 로그인을 수행할때, 카카오 로그인 진행 후(accessToken 발급), 서버 로그인 진행시, timeout 에러가 발생하여 제대로 로그인이 진행되지 않는 경우, 앱에 저장된 토큰(accessToken, uuid)를 모두 제거 
- 다시 앱에 진입할 경우, 카카오측에선 accessToken을 발급했고, 이 토큰이 유효하기 때문에 자동 로그인이 되어 홈화면으로 넘어가는 문제 발생 -> 이때 유저정보 api 와 같은 헤더에 accessToken을 필요로 하는 api를 호출하게 될 경우, 앱내에 저장된 accessToken이 존재하지 않기 때문에 문제 발생

- 따라서 앱내에 accessToken 이 정상적으로 저장되어있고, 이 토큰이 유효할때에만 자동로그인이 되도록 로직 변경

한계: 토큰의 유효성을 검사할때는 앱내에 저장된 토큰을 통해 하는 것이 아니라, AuthApiClient.instance.hasToken, AuthApiClient.instance.accessTokenInfo 와 같은 함수를 통해 진행하는 것이기에, SSOT 원칙의 위배되는감이 없지 않아 있음... 
그리고 이렇게 클라에서 토큰에 대한 유효성을 검사해도 현재 유저정보 API(/me)를 호출할 때, 문제가 서버관련 에러가 발생함(클라에선 500, 서버에러는 401) 결국에는 서버에서도 카카오측에 통신을 할때 토큰의 유효성 검사를 하는 것을 알 수 있음.

해결: 토큰의 유효성 검사 자체를 서버에 위임하는게 SSOT 원칙에 들어맞으므로 그게 더 적절한 방법일 것 같음   