### PR TITLE
[FIX] Background 이미지가 언제나 화면 전체를 채우도록 수정

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
 
     <application
         android:name=".ILabApplication"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"

--- a/build-logic/src/main/kotlin/com/nexters/ilab/android/Config.kt
+++ b/build-logic/src/main/kotlin/com/nexters/ilab/android/Config.kt
@@ -4,8 +4,8 @@ internal object ApplicationConfig {
     const val MinSdk = 26
     const val TargetSdk = 34
     const val CompileSdk = 34
-    const val VersionCode = 3
-    const val VersionName = "1.0.2"
+    const val VersionCode = 4
+    const val VersionName = "1.0.3"
     val JavaVersion = org.gradle.api.JavaVersion.VERSION_17
     const val JavaVersionAsInt = 17
 }

--- a/core/ui/src/main/kotlin/com/nexters/ilab/core/ui/component/Image.kt
+++ b/core/ui/src/main/kotlin/com/nexters/ilab/core/ui/component/Image.kt
@@ -97,7 +97,7 @@ fun BackgroundImage(
     resId: Int,
     contentDescription: String,
     modifier: Modifier = Modifier,
-    contentScale: ContentScale = ContentScale.Fit,
+    contentScale: ContentScale = ContentScale.Crop,
 ) {
     if (LocalInspectionMode.current) {
         Box(modifier = Modifier.fillMaxSize())

--- a/feature/home/src/main/kotlin/com/nexters/ilab/android/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/nexters/ilab/android/feature/home/HomeScreen.kt
@@ -71,7 +71,6 @@ import com.nexters.ilab.core.ui.component.PagerIndicator
 import com.nexters.ilab.core.ui.component.ServerErrorDialog
 import com.nexters.ilab.core.ui.component.TopAppBarNavigationType
 
-// TODO 하단 스타일과 스타일 입력 화면 연동
 @Composable
 internal fun HomeRoute(
     padding: PaddingValues,

--- a/feature/login/src/main/kotlin/com/nexters/ilab/android/feature/login/LoginScreen.kt
+++ b/feature/login/src/main/kotlin/com/nexters/ilab/android/feature/login/LoginScreen.kt
@@ -74,6 +74,7 @@ internal fun LoginRoute(
                             resource.getString(R.string.unknown_error_message)
                         }
                     }
+
                     is SocketTimeoutException -> resource.getString(R.string.server_error_message)
                     else -> resource.getString(R.string.unknown_error_message)
                 },
@@ -139,10 +140,6 @@ internal fun LoginScreen(
     onLoginClick: () -> Unit,
 ) {
     Box(modifier = Modifier.fillMaxSize()) {
-        if (uiState.isLoading) {
-            LoadingIndicator(modifier = Modifier.fillMaxSize())
-        }
-
         BackgroundImage(
             resId = R.drawable.bg_login_screen,
             contentDescription = "Background Image for Login Screen",
@@ -153,6 +150,9 @@ internal fun LoginScreen(
         LoginContent(
             onLoginClick = onLoginClick,
         )
+        if (uiState.isLoading) {
+            LoadingIndicator()
+        }
     }
 }
 


### PR DESCRIPTION
- 배경 이미지가 언제나 전체 화면을 차지하도록 수정
- allowBackup 비활성화 (앱내의 데이터를 구글 클라우드에 자동으로 백업하는 것을 비활성화)

테블릿과 같이 큰 화면으로 앱을 실행 했을 경우

|이전|이후|
|:-----:|:-----:|
|<img width="360" src="https://github.com/Nexters/ilab-android/assets/51016231/2309d041-b5a3-4960-9419-f190a1d92c8e">|<img width="360" src="https://github.com/Nexters/ilab-android/assets/51016231/293810eb-a0bb-4dd3-825d-b185c926396b">|

아직 남아있는 문제: 이미지 생성 관련 서버에러(해결 중), 로그인 이후 시간이 지난 후, 토큰은 유효하지만, 내 정보화면에 진입하면 서버에러가 발생하는 건(클라: 500, 서버: 401)