### PR TITLE
[FEAT] Firebase Crashlytics를 AndroidX Startup 라이브러리를 활용하여 초기화하는 Initializer 클래스 추가

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -51,7 +51,7 @@ jobs:
                 run: ./gradlew ktlintCheck
 
             -   name: Build with Gradle
-                run: ./gradlew build
+                run: ./gradlew buildDebug --stacktrace
 
             -   name: send to Slack
                 uses: 8398a7/action-slack@v3

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,6 +37,10 @@
                 android:name="com.nexters.ilab.android.initializer.KakaoSDKInitializer"
                 android:value="androidx.startup" />
 
+            <meta-data
+                android:name="com.nexters.ilab.android.initializer.FirebaseCrashlyticsInitializer"
+                android:value="androidx.startup" />
+
         </provider>
 
         <provider

--- a/app/src/main/kotlin/com/nexters/ilab/android/initializer/FirebaseCrashlyticsInitializer.kt
+++ b/app/src/main/kotlin/com/nexters/ilab/android/initializer/FirebaseCrashlyticsInitializer.kt
@@ -1,0 +1,16 @@
+package com.nexters.ilab.android.initializer
+
+import android.content.Context
+import androidx.startup.Initializer
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.nexters.ilab.android.BuildConfig
+
+class FirebaseCrashlyticsInitializer : Initializer<Unit> {
+  override fun create(context: Context) {
+    FirebaseCrashlytics.getInstance().setCrashlyticsCollectionEnabled(!BuildConfig.DEBUG)
+  }
+
+  override fun dependencies(): List<Class<out Initializer<*>>> {
+    return emptyList()
+  }
+}

--- a/app/src/main/kotlin/com/nexters/ilab/android/initializer/FirebaseCrashlyticsInitializer.kt
+++ b/app/src/main/kotlin/com/nexters/ilab/android/initializer/FirebaseCrashlyticsInitializer.kt
@@ -6,11 +6,11 @@ import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.nexters.ilab.android.BuildConfig
 
 class FirebaseCrashlyticsInitializer : Initializer<Unit> {
-  override fun create(context: Context) {
-    FirebaseCrashlytics.getInstance().setCrashlyticsCollectionEnabled(!BuildConfig.DEBUG)
-  }
+    override fun create(context: Context) {
+        FirebaseCrashlytics.getInstance().setCrashlyticsCollectionEnabled(!BuildConfig.DEBUG)
+    }
 
-  override fun dependencies(): List<Class<out Initializer<*>>> {
-    return emptyList()
-  }
+    override fun dependencies(): List<Class<out Initializer<*>>> {
+        return emptyList()
+    }
 }


### PR DESCRIPTION
- release variant 에서만 firebase crashlytics 가 수행되도록 설정

_앱 시작 라이브러리를 사용하면 애플리케이션 시작 시 구성요소를 간단하고 효율적으로 초기화할 수 있습니다. 라이브러리 개발자는 물론 앱 개발자도 앱 시작을 사용하여 시작 시퀀스를 간소화하고 초기화 순서를 명시적으로 설정할 수 있습니다._

_초기화해야 하는 각 구성요소에 관해 별도의 콘텐츠 제공자를 정의하는 대신 앱 시작을 사용하면 단일 콘텐츠 제공자를 공유하는 구성요소 이니셜라이저를 정의할 수 있습니다. 이렇게 하면 앱 시작 시간이 크게 개선됩니다._

출처) 
https://developer.android.com/topic/libraries/app-startup?hl=ko

---
- 앱을 release 로 빌드 할 경우 정상적으로 작동되나, ci 에서 release 빌드시 keystore file 을 찾지 못하는 문제 발생
```
* What went wrong:
Execution failed for task ':app:validateSigningRelease'.
> Keystore file '***' not found for signing config 'release'.
```
-> build workflow 이전에 keystore.properties 를 generate 함에도 불구하고 지속적으로 문제가 발생
-> 우선은 ci 통과를 위해 ci 내에 Build workflow 를 debug 빌드만 실행되도록 조정해보았는데, keystore 파일을 generate 하는 방식에 문제가 있는 것인지 알아볼 필요가 있음.. 
