### PR TITLE
[FIX] 마이 페이지 화면 AccessToken 만료, 서버 에러 대응 

### DIFF
--- a/build-logic/src/main/kotlin/com/nexters/ilab/android/Config.kt
+++ b/build-logic/src/main/kotlin/com/nexters/ilab/android/Config.kt
@@ -4,8 +4,8 @@ internal object ApplicationConfig {
     const val MinSdk = 26
     const val TargetSdk = 34
     const val CompileSdk = 34
-    const val VersionCode = 6
-    const val VersionName = "1.0.5"
+    const val VersionCode = 7
+    const val VersionName = "1.0.6"
     val JavaVersion = org.gradle.api.JavaVersion.VERSION_17
     const val JavaVersionAsInt = 17
 }

--- a/core/data/src/main/kotlin/com/nexters/ilab/android/core/data/repository/TokenRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/nexters/ilab/android/core/data/repository/TokenRepositoryImpl.kt
@@ -31,7 +31,7 @@ class TokenRepositoryImpl @Inject constructor(
         return dataSource.getUUID()
     }
 
-    override suspend fun clear() {
-        dataSource.clear()
+    override suspend fun clearAuthToken() {
+        dataSource.clearAuthToken()
     }
 }

--- a/core/datastore/src/main/kotlin/com/nexters/ilab/android/core/datastore/TokenDataSource.kt
+++ b/core/datastore/src/main/kotlin/com/nexters/ilab/android/core/datastore/TokenDataSource.kt
@@ -7,5 +7,5 @@ interface TokenDataSource {
     suspend fun getAccessToken(): String
     suspend fun getRefreshToken(): String
     suspend fun getUUID(): Long
-    suspend fun clear()
+    suspend fun clearAuthToken()
 }

--- a/core/datastore/src/main/kotlin/com/nexters/ilab/android/core/datastore/TokenDataSourceImpl.kt
+++ b/core/datastore/src/main/kotlin/com/nexters/ilab/android/core/datastore/TokenDataSourceImpl.kt
@@ -51,7 +51,7 @@ class TokenDataSourceImpl @Inject constructor(
             else throw exception
         }.first()[KEY_REFRESH_TOKEN] ?: ""
 
-    override suspend fun clear() {
+    override suspend fun clearAuthToken() {
         dataStore.edit { it.clear() }
     }
 }

--- a/core/designsystem/build.gradle.kts
+++ b/core/designsystem/build.gradle.kts
@@ -12,7 +12,6 @@ android {
 dependencies {
     implementations(
         libs.androidx.core,
-        libs.androidx.splash,
         libs.coil.compose,
     )
 }

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -24,6 +24,7 @@
     <string name="mypage_name_postfix">님</string>
     <string name="mypage_dropdown_delete">삭제하기</string>
     <string name="mypage_dropdown_share">공유하기</string>
+    <string name="mypage_logout">로그인 세션이 종료되어 다시 로그인이 필요합니다.</string>
 
     <!--    Setting -->
     <string name="setting_title">설정</string>

--- a/core/domain/src/main/kotlin/com/nexters/ilab/android/core/domain/repository/TokenRepository.kt
+++ b/core/domain/src/main/kotlin/com/nexters/ilab/android/core/domain/repository/TokenRepository.kt
@@ -7,5 +7,5 @@ interface TokenRepository {
     suspend fun getAccessToken(): String
     suspend fun getRefreshToken(): String
     suspend fun getUUID(): Long
-    suspend fun clear()
+    suspend fun clearAuthToken()
 }

--- a/feature/intro/src/main/kotlin/com/nexters/ilab/android/feature/intro/IntroActivity.kt
+++ b/feature/intro/src/main/kotlin/com/nexters/ilab/android/feature/intro/IntroActivity.kt
@@ -3,13 +3,11 @@ package com.nexters.ilab.android.feature.intro
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.activity.viewModels
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.graphics.Color
-import androidx.activity.enableEdgeToEdge
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import com.nexters.ilab.android.core.designsystem.theme.ILabTheme
-import com.nexters.ilab.android.feature.intro.viewmodel.IntroViewModel
 import com.nexters.ilab.android.feature.navigator.LoginNavigator
 import com.nexters.ilab.android.feature.navigator.MainNavigator
 import dagger.hilt.android.AndroidEntryPoint
@@ -18,8 +16,6 @@ import javax.inject.Inject
 
 @AndroidEntryPoint
 class IntroActivity : ComponentActivity() {
-    private val viewModel: IntroViewModel by viewModels()
-
     @Inject
     lateinit var loginNavigator: LoginNavigator
 
@@ -58,7 +54,6 @@ class IntroActivity : ComponentActivity() {
                             withFinish = true,
                         )
                     },
-                    viewModel = viewModel,
                 )
             }
         }

--- a/feature/intro/src/main/kotlin/com/nexters/ilab/android/feature/intro/viewmodel/IntroViewModel.kt
+++ b/feature/intro/src/main/kotlin/com/nexters/ilab/android/feature/intro/viewmodel/IntroViewModel.kt
@@ -39,7 +39,7 @@ class IntroViewModel @Inject constructor(
 
     fun autoLoginFail() = intent {
         viewModelScope.launch {
-            repository.clear()
+            repository.clearAuthToken()
             postSideEffect(IntroSideEffect.AutoLoginFail)
         }
     }

--- a/feature/login/src/main/kotlin/com/nexters/ilab/android/feature/login/LoginActivity.kt
+++ b/feature/login/src/main/kotlin/com/nexters/ilab/android/feature/login/LoginActivity.kt
@@ -4,11 +4,9 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.activity.viewModels
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.graphics.Color
 import com.nexters.ilab.android.core.designsystem.theme.ILabTheme
-import com.nexters.ilab.android.feature.login.viewmodel.LoginViewModel
 import com.nexters.ilab.android.feature.navigator.MainNavigator
 import dagger.hilt.android.AndroidEntryPoint
 import tech.thdev.compose.exteions.system.ui.controller.rememberExSystemUiController
@@ -16,8 +14,6 @@ import javax.inject.Inject
 
 @AndroidEntryPoint
 class LoginActivity : ComponentActivity() {
-    private val viewModel: LoginViewModel by viewModels()
-
     @Inject
     lateinit var mainNavigator: MainNavigator
 
@@ -46,7 +42,6 @@ class LoginActivity : ComponentActivity() {
                             withFinish = true,
                         )
                     },
-                    viewModel = viewModel,
                 )
             }
         }

--- a/feature/login/src/main/kotlin/com/nexters/ilab/android/feature/login/viewmodel/LoginViewModel.kt
+++ b/feature/login/src/main/kotlin/com/nexters/ilab/android/feature/login/viewmodel/LoginViewModel.kt
@@ -40,7 +40,7 @@ class LoginViewModel @Inject constructor(
                 }
                 .onFailure { exception ->
                     Timber.e(exception)
-                    tokenRepository.clear()
+                    tokenRepository.clearAuthToken()
                     postSideEffect(LoginSideEffect.LoginFail(exception))
                 }
             reduce {

--- a/feature/main/src/main/AndroidManifest.xml
+++ b/feature/main/src/main/AndroidManifest.xml
@@ -5,15 +5,9 @@
 
         <activity
             android:name=".MainActivity"
-            android:exported="true"
+            android:exported="false"
             android:screenOrientation="portrait"
             android:theme="@style/Theme.ILab">
-
-<!--            <intent-filter>-->
-<!--                <action android:name="android.intent.action.MAIN" />-->
-
-<!--                <category android:name="android.intent.category.LAUNCHER" />-->
-<!--            </intent-filter>-->
 
         </activity>
 

--- a/feature/main/src/main/kotlin/com/nexters/ilab/android/feature/main/MainScreen.kt
+++ b/feature/main/src/main/kotlin/com/nexters/ilab/android/feature/main/MainScreen.kt
@@ -108,6 +108,7 @@ internal fun MainScreen(
                     padding = padding,
                     onSettingClick = navigator::navigateToSetting,
                     onNavigateToMyAlbum = navigator::navigateToMyAlbum,
+                    onNavigateToLogin = onNavigateToLogin,
                 )
 
                 myAlbumNavGraph(

--- a/feature/mypage/src/main/kotlin/com/nexters/ilab/android/feature/mypage/navigation/MyPageNavigation.kt
+++ b/feature/mypage/src/main/kotlin/com/nexters/ilab/android/feature/mypage/navigation/MyPageNavigation.kt
@@ -17,12 +17,14 @@ fun NavGraphBuilder.myPageNavGraph(
     padding: PaddingValues,
     onSettingClick: () -> Unit,
     onNavigateToMyAlbum: (String, List<String>) -> Unit,
+    onNavigateToLogin: () -> Unit,
 ) {
     composable(route = MY_PAGE_ROUTE) {
         MyPageRoute(
             padding = padding,
             onSettingClick = onSettingClick,
             onNavigateToMyAlbum = onNavigateToMyAlbum,
+            onNavigateToLogin = onNavigateToLogin,
         )
     }
 }

--- a/feature/mypage/src/main/kotlin/com/nexters/ilab/android/feature/mypage/viewmodel/MyPageSideEffect.kt
+++ b/feature/mypage/src/main/kotlin/com/nexters/ilab/android/feature/mypage/viewmodel/MyPageSideEffect.kt
@@ -1,9 +1,13 @@
 package com.nexters.ilab.android.feature.mypage.viewmodel
 
+import com.nexters.ilab.android.core.common.UiText
+
 sealed interface MyPageSideEffect {
     data class ShareMyAlbum(val imageUriList: List<String>) : MyPageSideEffect
     data class NavigateToMyAlbum(
         val imageUrlList: List<String>,
         val imageStyle: String,
     ) : MyPageSideEffect
+
+    data class ShowToast(val message: UiText) : MyPageSideEffect
 }

--- a/feature/mypage/src/main/kotlin/com/nexters/ilab/android/feature/mypage/viewmodel/MyPageViewModel.kt
+++ b/feature/mypage/src/main/kotlin/com/nexters/ilab/android/feature/mypage/viewmodel/MyPageViewModel.kt
@@ -3,10 +3,13 @@ package com.nexters.ilab.android.feature.mypage.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.nexters.ilab.android.core.common.ErrorHandlerActions
+import com.nexters.ilab.android.core.common.UiText
 import com.nexters.ilab.android.core.common.handleException
+import com.nexters.ilab.android.core.designsystem.R
 import com.nexters.ilab.android.core.domain.repository.AuthRepository
 import com.nexters.ilab.android.core.domain.repository.DeleteMyAlbumRepository
 import com.nexters.ilab.android.core.domain.repository.FileRepository
+import com.nexters.ilab.android.core.domain.repository.TokenRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.launch
@@ -23,6 +26,7 @@ class MyPageViewModel @Inject constructor(
     private val authRepository: AuthRepository,
     private val fileRepository: FileRepository,
     private val deleteMyAlbumRepository: DeleteMyAlbumRepository,
+    private val tokenRepository: TokenRepository,
 ) : ViewModel(), ContainerHost<MyPageState, MyPageSideEffect>, ErrorHandlerActions {
     override val container = container<MyPageState, MyPageSideEffect>(MyPageState())
 
@@ -135,8 +139,12 @@ class MyPageViewModel @Inject constructor(
         }
     }
 
-    override fun onCleared() {
-        super.onCleared()
-        Timber.d("MyPageViewModel is cleared")
+    fun clearAuthToken() = intent {
+        viewModelScope.launch {
+            tokenRepository.clearAuthToken()
+            postSideEffect(
+                MyPageSideEffect.ShowToast(UiText.StringResource(R.string.mypage_logout)),
+            )
+        }
     }
 }

--- a/feature/setting/src/main/kotlin/com/nexters/ilab/android/feature/setting/viewmodel/SettingViewModel.kt
+++ b/feature/setting/src/main/kotlin/com/nexters/ilab/android/feature/setting/viewmodel/SettingViewModel.kt
@@ -41,11 +41,7 @@ class SettingViewModel @Inject constructor(
 
     fun getVersionInfo(context: Context): String {
         val packageInfo: PackageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
-        if (packageInfo != null) {
-            return packageInfo.versionName
-        } else {
-            return "버전 정보가 없습니다."
-        }
+        return packageInfo.versionName
     }
 
     fun deleteAccount() = intent {

--- a/feature/setting/src/main/kotlin/com/nexters/ilab/android/feature/setting/viewmodel/SettingViewModel.kt
+++ b/feature/setting/src/main/kotlin/com/nexters/ilab/android/feature/setting/viewmodel/SettingViewModel.kt
@@ -29,7 +29,7 @@ class SettingViewModel @Inject constructor(
             reduce { state.copy(isLoading = true) }
             authRepository.signOut()
                 .onSuccess {
-                    tokenRepository.clear()
+                    tokenRepository.clearAuthToken()
                     postSideEffect(SettingSideEffect.LogoutSuccess)
                 }.onFailure { exception ->
                     Timber.d("$exception")
@@ -54,7 +54,7 @@ class SettingViewModel @Inject constructor(
                 reduce { state.copy(isLoading = true) }
                 authRepository.deleteAccount()
                     .onSuccess {
-                        tokenRepository.clear()
+                        tokenRepository.clearAuthToken()
                         postSideEffect(SettingSideEffect.LogoutSuccess)
                     }.onFailure { exception ->
                         Timber.d("$exception")

--- a/feature/uploadphoto/src/main/kotlin/com/nexters/ilab/android/feature/uploadphoto/navigation/UploadPhotoNavigation.kt
+++ b/feature/uploadphoto/src/main/kotlin/com/nexters/ilab/android/feature/uploadphoto/navigation/UploadPhotoNavigation.kt
@@ -58,7 +58,6 @@ fun NavGraphBuilder.uploadPhotoNavGraph(
     ) {
         composable(route = UPLOAD_ROUTE) { entry ->
             val viewModel = entry.sharedViewModel<UploadPhotoViewModel>(navController)
-
             UploadPhotoRoute(
                 onBackClick = onBackClick,
                 onNavigateToPrivacyPolicy = onNavigateToPrivacyPolicy,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,7 +55,6 @@ gradle-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.
 kotlin-ktlint = { group = "com.pinterest", name = "ktlint", version.ref = "kotlin-ktlint-source" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
-kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "kotlinx-datetime" }
 kotlinx-collections-immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinx-collections-immutable" }
 
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }


### PR DESCRIPTION
- 토큰이 만료된 경우에 대해서, 서버 에러 다이얼로그를 띄워, 재시도를 하는 로직이 현재 상황에선 의미가 없고, 불필요한 API 호출을 야기시키기 때문에, 서버 에러가 발생할 경우 사용자에게 토스트 메세지를 통해 로그인 세션이 만료되었음을 알리고, 로그인 화면으로 이동하는 로직으로 임시 대응

- 로컬에 저장된 토큰을 제거하는 함수인 clear 라는 함수의 네이밍이 추상적이므로, clearAuthToken 으로 좀 더 직관적으로 변경