### PR TITLE
[FIX] 내 정보 API 호출 시점 변경

### DIFF
--- a/feature/mypage/src/main/kotlin/com/nexters/ilab/android/feature/mypage/MyPageScreen.kt
+++ b/feature/mypage/src/main/kotlin/com/nexters/ilab/android/feature/mypage/MyPageScreen.kt
@@ -159,6 +159,10 @@ internal fun MyPageScreen(
     onNavigateToLogin: () -> Unit,
     clearAuthToken: () -> Unit,
 ) {
+    LaunchedEffect(key1 = Unit) {
+        getUserInfo()
+    }
+
     Column(
         modifier = Modifier
             .fillMaxSize()

--- a/feature/mypage/src/main/kotlin/com/nexters/ilab/android/feature/mypage/viewmodel/MyPageViewModel.kt
+++ b/feature/mypage/src/main/kotlin/com/nexters/ilab/android/feature/mypage/viewmodel/MyPageViewModel.kt
@@ -18,7 +18,6 @@ import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.viewmodel.container
-import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -29,11 +28,6 @@ class MyPageViewModel @Inject constructor(
     private val tokenRepository: TokenRepository,
 ) : ViewModel(), ContainerHost<MyPageState, MyPageSideEffect>, ErrorHandlerActions {
     override val container = container<MyPageState, MyPageSideEffect>(MyPageState())
-
-    init {
-        Timber.d("MyPageViewModel is initialized")
-        getUserInfo()
-    }
 
     fun getUserInfo() = intent {
         viewModelScope.launch {


### PR DESCRIPTION
- 기존의 로직에선 MyPageViewModel 의 init {} 블럭에서 내 정보 API 를 호출했었음
- 허나 그럴 경우, 뷰모델이 파괴되지 않으면, 더이상 API를 호출하지 않기 때문에, 이미지를 생성하고 다시 MyPage에 진입하여도 API가 호출되지 않아 새로 생성된 이미지를 확인할 수 없는 문제가 발생 -> 앱을 껐다 켜야 반영됨 
- Navigation Bar 과 연동된 화면의 뷰모델의 생명주기가 다른 단일 화면들과 어떻게 다른지 알아볼 필요가 있음
- 따라서 해당 화면에 진입할때마다 API를 호출하여 새로 갱신된 정보를 받아야 하므로 화면 컴포저블 내에 LaunchedEffect(key1 = Unit) 내에서 API를 호출하여 리컴포지션 될 때마다(화면 진입, 앨범 삭제 등등) 호출되도록 호출 시점 변경

다만 지금 슬랙에 언급한 API 관련 문제가 존재하여 해당 문제를 먼저 해결해야할듯(서버 데이터 관련 문제)